### PR TITLE
feat(respack): add -t respack target for RESPACK input generation

### DIFF
--- a/docs/en/source/cif2x/command/index.rst
+++ b/docs/en/source/cif2x/command/index.rst
@@ -40,6 +40,8 @@ DESCRIPTION:
 
     - ``AkaiKKR``: generates input files for AkaiKKR.
 
+    - ``respack``: generates the RESPACK workflow — the Quantum ESPRESSO inputs (``scf``/``nscf``/``bands`` tasks) and the RESPACK control file ``input.in`` (a ``mode: respack`` task). The structure must be the standardized primitive cell (``structure.use_primitive: true``, ``use_ibrav: false``). ``N_wannier`` and the energy windows are user physics supplied in the ``content``/template; initial guesses use SCDM (``N_initial_guess = 0``), targeting the ``respack-wannier-py`` port. The ``nscf`` task must set ``nosym = .true.``/``noinv = .true.`` for ``qe2respack``. Run order: ``scf`` → ``nscf`` → ``qe2respack`` → ``respack``.
+
   - ``--dry-run``
 
     prints the generated input files to standard output instead of writing them to disk. This is useful for previewing the result without creating any files or directories.

--- a/docs/en/source/cif2x/command/index.rst
+++ b/docs/en/source/cif2x/command/index.rst
@@ -40,7 +40,7 @@ DESCRIPTION:
 
     - ``AkaiKKR``: generates input files for AkaiKKR.
 
-    - ``respack``: generates the RESPACK workflow — the Quantum ESPRESSO inputs (``scf``/``nscf``/``bands`` tasks) and the RESPACK control file ``input.in`` (a ``mode: respack`` task). The structure must be the standardized primitive cell (``structure.use_primitive: true``, ``use_ibrav: false``). ``N_wannier`` and the energy windows are user physics supplied in the ``content``/template; initial guesses use SCDM (``N_initial_guess = 0``), targeting the ``respack-wannier-py`` port. The ``nscf`` task must set ``nosym = .true.``/``noinv = .true.`` for ``qe2respack``. Run order: ``scf`` → ``nscf`` → ``qe2respack`` → ``respack``.
+    - ``respack``: generates the RESPACK workflow — the Quantum ESPRESSO inputs (``scf``/``nscf`` tasks, plus an optional ``bands`` task) and the RESPACK control file ``input.in`` (a ``mode: respack`` task). The structure must be the **standardized primitive cell** that pymatgen's high-symmetry k-path assumes — set ``structure.use_primitive: true`` and ``use_ibrav: false``, and provide a standardized primitive structure; for non-cubic cells a mismatched cell makes the written k-path inconsistent with the QE cell (cif2x logs a warning). ``N_wannier`` and the energy windows are user physics supplied in the ``content``/template; initial guesses use SCDM (``N_initial_guess = 0``), targeting the ``respack-wannier-py`` port. The ``nscf`` task must set ``nosym = .true.``/``noinv = .true.`` for ``qe2respack``. Run order: ``scf`` → ``nscf`` → ``qe2respack`` → ``respack``.
 
   - ``--dry-run``
 

--- a/docs/ja/source/cif2x/command/index.rst
+++ b/docs/ja/source/cif2x/command/index.rst
@@ -40,7 +40,7 @@ cif2x
 
     - ``AkaiKKR``: AkaiKKR向け入力ファイルを生成します。
 
-    - ``respack``: RESPACK ワークフロー一式を生成します。Quantum ESPRESSO 入力(``scf``/``nscf``/``bands`` タスク)と RESPACK 制御ファイル ``input.in``(``mode: respack`` タスク)を出力します。構造は標準プリミティブセル(``structure.use_primitive: true``、``use_ibrav: false``)である必要があります。``N_wannier`` とエネルギー窓は ``content``/テンプレートで与える物理量で、初期ゲスは SCDM(``N_initial_guess = 0``、``respack-wannier-py`` を対象)です。``nscf`` タスクには ``qe2respack`` 用に ``nosym = .true.``/``noinv = .true.`` を設定してください。実行順序: ``scf`` → ``nscf`` → ``qe2respack`` → ``respack``。
+    - ``respack``: RESPACK ワークフロー一式を生成します。Quantum ESPRESSO 入力(``scf``/``nscf`` タスク、および任意で ``bands`` タスク)と RESPACK 制御ファイル ``input.in``(``mode: respack`` タスク)を出力します。構造は pymatgen の高対称 k 経路が前提とする**標準プリミティブセル**である必要があります(``structure.use_primitive: true``、``use_ibrav: false`` を指定し、標準プリミティブ構造を与えてください)。非立方系で不一致のセルを与えると、書き出される k 経路が QE のセルと不整合になります(cif2x は警告を出力します)。``N_wannier`` とエネルギー窓は ``content``/テンプレートで与える物理量で、初期ゲスは SCDM(``N_initial_guess = 0``、``respack-wannier-py`` を対象)です。``nscf`` タスクには ``qe2respack`` 用に ``nosym = .true.``/``noinv = .true.`` を設定してください。実行順序: ``scf`` → ``nscf`` → ``qe2respack`` → ``respack``。
 
   - ``--dry-run``
 

--- a/docs/ja/source/cif2x/command/index.rst
+++ b/docs/ja/source/cif2x/command/index.rst
@@ -40,6 +40,8 @@ cif2x
 
     - ``AkaiKKR``: AkaiKKR向け入力ファイルを生成します。
 
+    - ``respack``: RESPACK ワークフロー一式を生成します。Quantum ESPRESSO 入力(``scf``/``nscf``/``bands`` タスク)と RESPACK 制御ファイル ``input.in``(``mode: respack`` タスク)を出力します。構造は標準プリミティブセル(``structure.use_primitive: true``、``use_ibrav: false``)である必要があります。``N_wannier`` とエネルギー窓は ``content``/テンプレートで与える物理量で、初期ゲスは SCDM(``N_initial_guess = 0``、``respack-wannier-py`` を対象)です。``nscf`` タスクには ``qe2respack`` 用に ``nosym = .true.``/``noinv = .true.`` を設定してください。実行順序: ``scf`` → ``nscf`` → ``qe2respack`` → ``respack``。
+
   - ``--dry-run``
 
     生成される入力ファイルをディスクに書き込まず、標準出力に表示します。ファイルやディレクトリを作成せずに生成結果を確認したい場合に便利です。

--- a/docs/superpowers/plans/2026-07-01-respack-target.md
+++ b/docs/superpowers/plans/2026-07-01-respack-target.md
@@ -1,0 +1,710 @@
+# cif2x RESPACK target (`-t respack`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `respack` target that emits the RESPACK workflow in one run — QE `scf`/`nscf`/`bands` (reusing `Struct2QE`) plus the RESPACK control `input.in` (new `Struct2RESPACK`).
+
+**Architecture:** `-t respack` routes each `tasks:` entry by `mode` (QE modes → `Struct2QE`; `mode: respack` → `Struct2RESPACK`). `Struct2RESPACK` merges a namelist-only template with `content`, validates the physics it must (`N_wannier`, windows, `dense`, SCDM), auto-generates only the `&param_interpolation` k-path from `HighSymmKpath`, and renders `input.in` (namelists in RESPACK order with the k-coords block spliced after `&param_interpolation`). No production change to `Struct2QE`.
+
+**Tech Stack:** Python, f90nml, pymatgen (`HighSymmKpath`), pytest. Run from repo root (`tests/conftest.py` adds `src/`).
+
+---
+
+## Background facts (verified)
+
+- `input_validator.TARGETS` is a per-target table (aliases/required/allowed); `normalize_target` canonicalizes `-t`. `main._run` builds `struct = Cif2Struct(...)`, then `generator_cls = _generator_class(target)` and loops `tasks`. `_generator_class` resolves classes from module globals at call time.
+- `Cif2Struct` stores `use_ibrav` (`cif2struct.py:33`) but NOT `use_primitive` (used inline at `:93`); the `structure:` block is `info_dict["structure"]`, available in `_run` as `struct_params`.
+- `cards._generate_band_path` reads `HighSymmKpath(structure).kpath` → `{"kpoints":{label:coords}, "path":[[label,...],...]}` and surfaces pymatgen warnings through the logger (skipping `DeprecationWarning`).
+- `f90nml.Namelist({name: dict}).write(stream)` renders one namelist; keys are lowercased and alphabetically ordered (RESPACK reads case-insensitively and order-independently). A list value renders as `key = a, b`.
+- RESPACK `input.in` `&param_interpolation`: `N_sym_points` is a list (one positive int ≥2 per disjoint path); the k-coords block (format 0) follows the `/`, one `kx ky kz  ! label` line per high-symmetry point, segment by segment (verified in `respack-wannier-py` `input_parser.py:108-230`).
+- `utils.dryrun_emit(path, content)` prints a `# === path ===` header + content (used by other generators' `--dry-run`).
+
+## File structure
+
+- **Create** `src/cif2x/struct2respack.py` — `Struct2RESPACK` + helpers.
+- **Modify** `src/cif2x/input_validator.py` — add `respack` to `TARGETS`; respack mode-sensitive validation hook.
+- **Modify** `src/cif2x/main.py` — import `Struct2RESPACK`; respack per-task routing + `use_primitive`/`use_ibrav` guard.
+- **Create** `tests/test_respack.py` — generator + validation tests.
+- **Modify** `tests/test_main_cli.py` — respack dispatch tests.
+- **Modify** docs (`command/index.rst` en/ja) + add `sample/cif2x/respack/<case>/`.
+
+---
+
+## Task 1: `Struct2RESPACK` — generate `input.in`
+
+**Files:**
+- Create: `src/cif2x/struct2respack.py`
+- Test: `tests/test_respack.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_respack.py`:
+
+```python
+import io
+
+import pytest
+
+pytest.importorskip("pymatgen")
+pytest.importorskip("f90nml")
+
+import f90nml
+from pymatgen.core import Lattice, Structure
+
+from cif2x.input_validator import InputValidationError
+from cif2x.struct2respack import Struct2RESPACK
+
+
+class _Struct:
+    def __init__(self, structure):
+        self.structure = structure
+
+
+def _cubic():
+    return Structure(Lattice.cubic(3.8), ["Cu"], [[0, 0, 0]])
+
+
+_TEMPLATE = """&param_chiqw
+Ecut_for_eps = 5.0
+flg_cRPA = 1
+/
+&param_wannier
+N_wannier = 3
+Lower_energy_window = 11.0
+Upper_energy_window = 14.2
+/
+&param_interpolation
+dense = 8, 8, 8
+/
+&param_calc_int
+/
+"""
+
+
+def _write(tmp_path, text=_TEMPLATE):
+    p = tmp_path / "respack.in_tmpl"
+    p.write_text(text)
+    return str(p)
+
+
+def _render(tmp_path, structure=None, content=None, template=None):
+    params = {"template": template or _write(tmp_path), "content": content or {}}
+    gen = Struct2RESPACK(params, _Struct(structure or _cubic()))
+    return gen.render()
+
+
+def test_render_passes_through_n_wannier_and_windows(tmp_path):
+    out = _render(tmp_path)
+    nml = f90nml.reads(out)
+    assert nml["param_wannier"]["n_wannier"] == 3
+    assert nml["param_wannier"]["lower_energy_window"] == 11.0
+    assert nml["param_wannier"]["upper_energy_window"] == 14.2
+
+
+def test_render_forces_scdm(tmp_path):
+    out = _render(tmp_path)
+    nml = f90nml.reads(out)
+    assert nml["param_wannier"]["n_initial_guess"] == 0
+    # no Gaussian initial-guess line (a bare 'dxy ...' token) is emitted
+    assert "dxy" not in out
+
+
+def test_render_kpath_matches_highsymmkpath_segments(tmp_path):
+    from pymatgen.symmetry.bandstructure import HighSymmKpath
+    s = _cubic()
+    out = _render(tmp_path, structure=s)
+    nml = f90nml.reads(out)
+    kpath = HighSymmKpath(s).kpath
+    seg_lengths = [len(seg) for seg in kpath["path"]]
+    nsp = nml["param_interpolation"]["n_sym_points"]
+    nsp = [nsp] if isinstance(nsp, int) else list(nsp)
+    assert nsp == seg_lengths
+    # the k-coords block after &param_interpolation has sum(seg_lengths) lines
+    after = out.split("&param_interpolation", 1)[1]
+    coord_lines = [ln for ln in after.splitlines()
+                   if ln.strip() and not ln.strip().startswith(("/", "&"))
+                   and "=" not in ln]
+    assert len(coord_lines) == sum(seg_lengths)
+
+
+def test_missing_n_wannier_rejected(tmp_path):
+    t = _TEMPLATE.replace("N_wannier = 3\n", "")
+    with pytest.raises(InputValidationError, match="N_wannier"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_nonzero_n_initial_guess_rejected(tmp_path):
+    t = _TEMPLATE.replace("N_wannier = 3", "N_wannier = 3\nN_initial_guess = 3")
+    with pytest.raises(InputValidationError, match="N_initial_guess"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_window_order_rejected(tmp_path):
+    t = _TEMPLATE.replace("Upper_energy_window = 14.2", "Upper_energy_window = 9.0")
+    with pytest.raises(InputValidationError, match="window"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_non_param_namelist_rejected(tmp_path):
+    t = _TEMPLATE + "&system\nnoncolin = .true.\n/\n"
+    with pytest.raises(InputValidationError, match="namelist"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_trailing_content_rejected(tmp_path):
+    t = _TEMPLATE + "garbage line not in a namelist\n"
+    with pytest.raises(InputValidationError, match="namelist-only|outside"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_bad_dense_rejected(tmp_path):
+    t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8")
+    with pytest.raises(InputValidationError, match="dense"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_reading_sk_format_nonzero_rejected(tmp_path):
+    t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8, 8\nreading_sk_format = 1")
+    with pytest.raises(InputValidationError, match="reading_sk_format"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_write_input_dry_run(tmp_path, capsys):
+    params = {"template": _write(tmp_path), "content": {}}
+    gen = Struct2RESPACK(params, _Struct(_cubic()))
+    gen.write_input("input.in", str(tmp_path), dry_run=True)
+    out = capsys.readouterr().out
+    assert "input.in" in out and "&param_wannier" in out
+    assert not (tmp_path / "input.in").exists()
+    gen.write_input("input.in", str(tmp_path), dry_run=False)
+    assert (tmp_path / "input.in").exists()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_respack.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cif2x.struct2respack'`.
+
+- [ ] **Step 3: Implement `src/cif2x/struct2respack.py`**
+
+```python
+"""Generate a RESPACK ``input.in`` control file from a namelist-only template.
+
+``N_wannier`` and the physics (energy windows, dense, cRPA params) come from the
+template/``content``; cif2x only auto-generates the ``&param_interpolation``
+high-symmetry k-path (from pymatgen) and forces SCDM (``N_initial_guess = 0``).
+"""
+
+import io
+import logging
+import warnings
+from pathlib import Path
+
+import f90nml
+
+from cif2x.input_validator import InputValidationError
+from cif2x.utils import dryrun_emit
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_NAMELISTS = (
+    "param_chiqw", "param_wannier", "param_interpolation",
+    "param_visualization", "param_calc_int",
+)
+_NAMELIST_ORDER = _ALLOWED_NAMELISTS
+
+
+def _deepupdate(dst, src):
+    for k, v in src.items():
+        if isinstance(v, dict) and isinstance(dst.get(k), dict):
+            _deepupdate(dst[k], v)
+        else:
+            dst[k] = v
+
+
+def _has_content_outside_namelists(text):
+    """True if a non-blank, non-comment line sits outside a &name.../ block."""
+    inside = False
+    for raw in text.splitlines():
+        line = raw.split("!", 1)[0].strip()
+        if not line:
+            continue
+        if inside:
+            if line == "/" or line.endswith("/"):
+                inside = False
+        else:
+            if line.startswith("&"):
+                inside = not (line.endswith("/") or "/" in line[1:])
+            else:
+                return True
+    return False
+
+
+def _kpath(structure):
+    """Return (n_sym_points list, [(label, (kx,ky,kz)), ...]) from HighSymmKpath."""
+    from pymatgen.symmetry.bandstructure import HighSymmKpath
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        kpath = HighSymmKpath(structure).kpath
+    for w in caught:
+        if not issubclass(w.category, DeprecationWarning):
+            logger.warning("band path: %s", w.message)
+    coords = kpath["kpoints"]
+    segments = kpath["path"]
+    n_sym_points = [len(seg) for seg in segments]
+    rows = []
+    for seg in segments:
+        for label in seg:
+            c = coords[label]
+            rows.append((label, (float(c[0]), float(c[1]), float(c[2]))))
+    return n_sym_points, rows
+
+
+def _as_three_ints(value, *, key):
+    if isinstance(value, int):
+        return [value, value, value]
+    if isinstance(value, (list, tuple)) and len(value) == 3 and all(
+        isinstance(v, int) for v in value
+    ):
+        return list(value)
+    raise InputValidationError(
+        f"respack: '{key}' must be three integers (got {value!r}).")
+
+
+class Struct2RESPACK:
+    def __init__(self, params, struct):
+        self.params = params
+        self.struct = struct
+        self._data, self._n_sym_points, self._kpath_rows = self._build()
+
+    def _build(self):
+        template = self.params.get("template")
+        if not template:
+            raise InputValidationError("respack task: 'template' is required.")
+        path = Path(template)
+        if not path.exists():
+            raise InputValidationError(f"respack template not found: {template}")
+        text = path.read_text()
+        try:
+            nml = f90nml.reads(text)
+        except Exception as e:
+            raise InputValidationError(
+                f"failed to parse RESPACK template '{template}': {e}")
+        for name in nml:
+            if name not in _ALLOWED_NAMELISTS:
+                raise InputValidationError(
+                    f"respack template: unexpected namelist '&{name}'. Only RESPACK "
+                    f"&param_* namelists are allowed (namelist-only templates).")
+        if _has_content_outside_namelists(text):
+            raise InputValidationError(
+                "respack template: content outside &param_* namelists is not "
+                "allowed (templates are namelist-only; cif2x generates the "
+                "k-coords block).")
+
+        data = {k: dict(v) for k, v in nml.items()}
+        content = self.params.get("content") or {}
+        norm = {str(k).lower(): {str(kk).lower(): vv for kk, vv in (v or {}).items()}
+                for k, v in content.items()}
+        _deepupdate(data, norm)
+
+        wann = data.setdefault("param_wannier", {})
+        n_wannier = wann.get("n_wannier")
+        if not isinstance(n_wannier, int) or n_wannier <= 0:
+            raise InputValidationError(
+                "respack: &param_wannier 'N_wannier' must be a positive integer "
+                f"(got {n_wannier!r}); it is user physics and is not auto-derived.")
+        if wann.get("n_initial_guess", 0) not in (0, None):
+            raise InputValidationError(
+                "respack: v1 is SCDM-only — 'N_initial_guess' must be 0 (got "
+                f"{wann.get('n_initial_guess')!r}).")
+        wann["n_initial_guess"] = 0
+        lo = wann.get("lower_energy_window")
+        hi = wann.get("upper_energy_window")
+        if not isinstance(lo, (int, float)) or not isinstance(hi, (int, float)):
+            raise InputValidationError(
+                "respack: 'Lower_energy_window' and 'Upper_energy_window' are "
+                "required numeric values in &param_wannier.")
+        if lo >= hi:
+            raise InputValidationError(
+                f"respack: energy window must have lower < upper (got {lo} >= {hi}).")
+
+        interp = data.setdefault("param_interpolation", {})
+        if int(interp.get("reading_sk_format", 0)) != 0:
+            raise InputValidationError(
+                "respack: only reading_sk_format = 0 is supported.")
+        interp["dense"] = _as_three_ints(interp.get("dense"), key="dense")
+
+        n_sym_points, rows = _kpath(self.struct.structure)
+        interp["n_sym_points"] = n_sym_points
+        return data, n_sym_points, rows
+
+    def render(self):
+        out = []
+        for name in _NAMELIST_ORDER:
+            if name not in self._data:
+                continue
+            buf = io.StringIO()
+            f90nml.Namelist({name: self._data[name]}).write(buf)
+            out.append(buf.getvalue())
+            if name == "param_interpolation":
+                for label, (x, y, z) in self._kpath_rows:
+                    out.append("{:.6f} {:.6f} {:.6f}  ! {}\n".format(x, y, z, label))
+        return "".join(out)
+
+    def write_input(self, output_file, output_dir, dry_run=False):
+        content = self.render()
+        if dry_run:
+            dryrun_emit(str(Path(output_dir, output_file)), content)
+            return
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        with open(Path(output_dir, output_file), "w") as fp:
+            fp.write(content)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/test_respack.py -q`
+Expected: PASS (all generator + validation tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cif2x/struct2respack.py tests/test_respack.py
+git commit -m "feat(respack): add Struct2RESPACK input.in generator"
+```
+End the body with a blank line then:
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+
+---
+
+## Task 2: Dispatch + validation (`-t respack` per-task routing)
+
+**Files:**
+- Modify: `src/cif2x/input_validator.py`
+- Modify: `src/cif2x/main.py`
+- Test: `tests/test_main_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_main_cli.py`:
+
+```python
+def test_respack_routes_qe_and_respack_tasks(monkeypatch, tmp_path):
+    pytest.importorskip("pymatgen")
+    captured = {"qe": [], "respack": []}
+
+    class _QE:
+        def __init__(self, params, struct):
+            pass
+
+        def write_input(self, *a, **k):
+            captured["qe"].append(True)
+
+    class _RP:
+        def __init__(self, params, struct):
+            pass
+
+        def write_input(self, *a, **k):
+            captured["respack"].append(True)
+
+    monkeypatch.setattr(main_mod, "Cif2Struct", lambda *a, **k: object())
+    monkeypatch.setattr(main_mod, "Struct2QE", _QE)
+    monkeypatch.setattr(main_mod, "Struct2RESPACK", _RP)
+    yf = tmp_path / "input.yaml"
+    yf.write_text(
+        "structure:\n  use_primitive: true\n"
+        "tasks:\n"
+        "  - mode: scf\n    output_file: scf.in\n"
+        "  - mode: respack\n    output_file: input.in\n    template: r.in_tmpl\n"
+    )
+    cif = tmp_path / "x.cif"
+    cif.write_text("")
+    monkeypatch.setattr(sys, "argv", ["cif2x", "-t", "respack", str(yf), str(cif)])
+    main_mod.main()
+    assert captured["qe"] == [True]
+    assert captured["respack"] == [True]
+
+
+def test_respack_rejects_non_workflow_mode(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(main_mod, "Cif2Struct", lambda *a, **k: object())
+    yf = tmp_path / "input.yaml"
+    yf.write_text(
+        "structure:\n  use_primitive: true\n"
+        "tasks:\n  - mode: relax\n    output_file: x.in\n"
+    )
+    cif = tmp_path / "x.cif"
+    cif.write_text("")
+    monkeypatch.setattr(sys, "argv", ["cif2x", "-t", "respack", str(yf), str(cif)])
+    with caplog.at_level("ERROR"):
+        with pytest.raises(SystemExit):
+            main_mod.main()
+    assert "relax" in caplog.text
+
+
+def test_respack_requires_primitive_cell(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(main_mod, "Cif2Struct", lambda *a, **k: object())
+    yf = tmp_path / "input.yaml"
+    yf.write_text(
+        "tasks:\n  - mode: respack\n    output_file: input.in\n    template: r\n"
+    )
+    cif = tmp_path / "x.cif"
+    cif.write_text("")
+    monkeypatch.setattr(sys, "argv", ["cif2x", "-t", "respack", str(yf), str(cif)])
+    with caplog.at_level("ERROR"):
+        with pytest.raises(SystemExit):
+            main_mod.main()
+    assert "use_primitive" in caplog.text
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_main_cli.py -q`
+Expected: FAIL — `respack` is not a known target (normalize_target raises), `Struct2RESPACK` not imported, no respack routing.
+
+- [ ] **Step 3: Add `respack` to the validator**
+
+In `src/cif2x/input_validator.py`, add to `TARGETS` (after the `akaikkr` entry):
+
+```python
+    "respack": {
+        "aliases": ("respack",),
+        "required": ("mode", "output_file"),
+        "allowed": _COMMON_ALLOWED | {"mode"},
+    },
+```
+
+(`_COMMON_ALLOWED` already includes `template`, `content`, `output_file`, `output_dir`, `optional`, which covers both QE-mode tasks and the respack task. Per-mode legality — only `scf`/`nscf`/`bands`/`respack` — is enforced at dispatch; the respack task's required `template` is enforced by `Struct2RESPACK.__init__` (a clean `InputValidationError`), a deliberate v1 simplification rather than mode-specific validator schemas.)
+
+- [ ] **Step 4: Wire respack routing into `main.py`**
+
+In `src/cif2x/main.py`, add the import after `from cif2x.struct2akaikkr import Struct2AkaiKKR`:
+
+```python
+from cif2x.struct2respack import Struct2RESPACK
+```
+
+Then replace the dispatch loop. Find, in `_run`, the block:
+
+```python
+    info_optional = info_dict.get("optional") or {}
+    generator_cls = _generator_class(target)
+
+    for idx, info in enumerate(info_dict["tasks"], start=1):
+        logger.info(f"start task {idx}")
+
+        params = {}
+        params.update(info)
+        if params.get("optional") is None:
+            params["optional"] = {}
+        deepupdate(params, {"optional": info_optional})
+
+        output_file = info.get("output_file")
+        output_dir = info.get("output_dir", ".")
+
+        generator = generator_cls(params, struct)
+        generator.write_input(output_file, output_dir, dry_run=args.dry_run)
+```
+
+and replace it with:
+
+```python
+    info_optional = info_dict.get("optional") or {}
+    generator_cls = None if target == "respack" else _generator_class(target)
+
+    if target == "respack":
+        if not struct_params.get("use_primitive") or struct_params.get("use_ibrav"):
+            raise InputValidationError(
+                "target 'respack' requires structure.use_primitive: true and "
+                "use_ibrav: false (the high-symmetry k-path needs the primitive cell).")
+
+    for idx, info in enumerate(info_dict["tasks"], start=1):
+        logger.info(f"start task {idx}")
+
+        params = {}
+        params.update(info)
+        if params.get("optional") is None:
+            params["optional"] = {}
+        deepupdate(params, {"optional": info_optional})
+
+        output_file = info.get("output_file")
+        output_dir = info.get("output_dir", ".")
+
+        if target == "respack":
+            gen_cls = _respack_generator(info.get("mode"), idx)
+        else:
+            gen_cls = generator_cls
+
+        generator = gen_cls(params, struct)
+        generator.write_input(output_file, output_dir, dry_run=args.dry_run)
+```
+
+Then add this helper next to `_generator_class`:
+
+```python
+def _respack_generator(mode, taskid):
+    """Pick the generator for a task under -t respack, by mode."""
+    if mode in ("scf", "nscf", "bands"):
+        return Struct2QE
+    if mode == "respack":
+        return Struct2RESPACK
+    raise InputValidationError(
+        f"task {taskid}: unsupported mode '{mode}' for target 'respack' "
+        "(use scf, nscf, bands, or respack).")
+```
+
+(The `struct_params` name already exists in `_run` — it is `info_dict.get("structure") or {}`, computed just before `struct` is built.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pytest tests/test_main_cli.py -q`
+Expected: PASS (routing, mode-reject, and primitive-cell tests, plus the existing CLI tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cif2x/input_validator.py src/cif2x/main.py tests/test_main_cli.py
+git commit -m "feat(respack): add -t respack target with per-task mode routing"
+```
+End the body with a blank line then:
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+
+---
+
+## Task 3: Documentation + sample
+
+**Files:**
+- Modify: `docs/en/source/cif2x/command/index.rst`, `docs/ja/source/cif2x/command/index.rst`
+- Create: `sample/cif2x/respack/SrVO3/{input.yaml, respack.in_tmpl, README.md}`
+
+- [ ] **Step 1: Document the target (EN)**
+
+In `docs/en/source/cif2x/command/index.rst`, in the `-t` *target* list, add a bullet after the AkaiKKR one:
+
+```rst
+    - ``respack``: generates the RESPACK workflow — the Quantum ESPRESSO inputs (``scf``/``nscf``/``bands`` tasks) and the RESPACK control file ``input.in`` (a ``mode: respack`` task). The structure must be the standardized primitive cell (``structure.use_primitive: true``, ``use_ibrav: false``). ``N_wannier`` and the energy windows are user physics supplied in the ``content``/template; initial guesses use SCDM (``N_initial_guess = 0``), targeting the ``respack-wannier-py`` port. The ``nscf`` task must set ``nosym = .true.``/``noinv = .true.`` for ``qe2respack``. Run order: ``scf`` → ``nscf`` → ``qe2respack`` → ``respack``.
+```
+
+- [ ] **Step 2: Document the target (JA)**
+
+In `docs/ja/source/cif2x/command/index.rst`, add the equivalent bullet after the AkaiKKR one:
+
+```rst
+    - ``respack``: RESPACK ワークフロー一式を生成します。Quantum ESPRESSO 入力(``scf``/``nscf``/``bands`` タスク)と RESPACK 制御ファイル ``input.in``(``mode: respack`` タスク)を出力します。構造は標準プリミティブセル(``structure.use_primitive: true``、``use_ibrav: false``)である必要があります。``N_wannier`` とエネルギー窓は ``content``/テンプレートで与える物理量で、初期ゲスは SCDM(``N_initial_guess = 0``、``respack-wannier-py`` を対象)です。``nscf`` タスクには ``qe2respack`` 用に ``nosym = .true.``/``noinv = .true.`` を設定してください。実行順序: ``scf`` → ``nscf`` → ``qe2respack`` → ``respack``。
+```
+
+- [ ] **Step 3: Create the sample**
+
+Create `sample/cif2x/respack/SrVO3/respack.in_tmpl`:
+
+```
+&param_chiqw
+Ecut_for_eps = 5.0
+flg_cRPA = 1
+/
+&param_wannier
+N_wannier = 3
+Lower_energy_window = 11.0
+Upper_energy_window = 14.2
+/
+&param_interpolation
+dense = 8, 8, 8
+/
+&param_calc_int
+/
+```
+
+Create `sample/cif2x/respack/SrVO3/input.yaml`:
+
+```yaml
+structure:
+  use_primitive: true
+  use_ibrav: false
+
+optional:
+  pseudo_dir: ./pseudo
+  pp_file: pp.csv
+
+tasks:
+  - mode: scf
+    output_file: scf.in
+    content:
+      control: { calculation: scf }
+      K_POINTS: { option: automatic, grid: [6, 6, 6] }
+  - mode: nscf
+    output_file: nscf.in
+    content:
+      control: { calculation: nscf }
+      system: { nosym: true, noinv: true }
+      K_POINTS: { option: crystal, grid: [6, 6, 6] }
+  - mode: respack
+    output_file: input.in
+    template: respack.in_tmpl
+```
+
+Create `sample/cif2x/respack/SrVO3/README.md`:
+
+```markdown
+# SrVO3 RESPACK sample
+
+`cif2x -t respack input.yaml SrVO3.cif` emits `scf.in`, `nscf.in`, and `input.in`.
+Provide `SrVO3.cif`, `pp.csv`, and the pseudopotentials under `./pseudo`.
+`N_wannier = 3` (t2g) and the energy windows are physics choices in
+`respack.in_tmpl`. Run order: scf → nscf → `qe2respack` → `respack` (the
+`respack-wannier-py` port; SCDM, `N_initial_guess = 0`).
+```
+
+- [ ] **Step 4: Lint (best-effort) and commit**
+
+Run: `python3 -c "import docutils" 2>/dev/null && for f in docs/en/source/cif2x/command/index.rst docs/ja/source/cif2x/command/index.rst; do python3 -m docutils "$f" /dev/null 2>&1 | grep -iE "severe|error" || echo "$f ok"; done || echo "docutils unavailable"`
+
+```bash
+git add docs/en/source/cif2x/command/index.rst docs/ja/source/cif2x/command/index.rst sample/cif2x/respack
+git commit -m "docs(respack): document the respack target and add a SrVO3 sample"
+```
+End the body with a blank line then:
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+
+---
+
+## Task 4: Full-suite + manual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `pytest -q`
+Expected: all tests pass (existing + `test_respack.py` + new CLI tests); no regression to QE/other targets.
+
+- [ ] **Step 2: Manual end-to-end render (dry-run, real structure)**
+
+Run from the sample dir (no QE/pseudos needed — `--dry-run` for the respack task path):
+```bash
+python3 -c "
+import sys; sys.path.insert(0, 'src')
+from pymatgen.core import Structure, Lattice
+from cif2x.struct2respack import Struct2RESPACK
+class S:
+    def __init__(s, st): s.structure = st
+st = Structure(Lattice.cubic(3.84), ['Sr','V','O','O','O'],
+               [[0.5,0.5,0.5],[0,0,0],[0.5,0,0],[0,0.5,0],[0,0,0.5]])
+tmpl='sample/cif2x/respack/SrVO3/respack.in_tmpl'
+print(Struct2RESPACK({'template': tmpl, 'content': {}}, S(st)).render())
+" | head -30
+```
+Expected: a valid `input.in` — `&param_wannier` with `n_wannier = 3`, `n_initial_guess = 0`; `&param_interpolation` with an `n_sym_points` list and a k-coords block of `kx ky kz  ! label` lines; no traceback.
+
+- [ ] **Step 3: Final commit (if any fixups were needed)**
+
+```bash
+git add -A && git commit -m "test(respack): verify end-to-end" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** `Struct2RESPACK` namelist-only template + content merge, N_wannier/window/dense/SCDM/reading_sk_format validation, multi-segment k-path from `HighSymmKpath`, render with k-block spliced after `&param_interpolation`, dry-run (Task 1); `-t respack` per-task mode routing + primitive-cell guard + validator entry (Task 2); docs (en/ja) + sample with nosym/noinv + run order + SCDM/port notes (Task 3); full-suite + manual render (Task 4). All spec sections map to a task.
+- **No QE change:** `Struct2QE._find_nbnd_info` is untouched (N_wannier is user physics); QE-mode tasks under respack reuse `Struct2QE` verbatim.
+- **Name consistency:** `Struct2RESPACK`, `_respack_generator`, `_kpath`, `_has_content_outside_namelists`, `_as_three_ints`, `TARGETS["respack"]` are consistent across tasks/tests.
+- **Monkeypatch safety:** `main.py` resolves `Struct2QE`/`Struct2RESPACK` from module globals at call time (via `_respack_generator`), so the CLI tests' monkeypatching works.

--- a/docs/superpowers/specs/2026-06-30-respack-target-design.md
+++ b/docs/superpowers/specs/2026-06-30-respack-target-design.md
@@ -7,11 +7,13 @@ Date: 2026-06-30
 Add a `respack` target so `cif2x -t respack input.yaml structure.cif` emits the
 whole RESPACK workflow in one run: the Quantum ESPRESSO inputs RESPACK consumes
 (`scf` / `nscf` / `bands`, via the existing QE generator) **and** the RESPACK
-control input `input.in` (a new generator). The structure-derived fields of
-`input.in` are auto-filled (number of Wannier functions, the high-symmetry
-k-path, the interpolation grid); physics parameters come from a template /
-`content`. Initial guesses use **SCDM** (`N_initial_guess = 0`), so no manual
-Gaussian projection block is emitted.
+control input `input.in` (a new generator). cif2x auto-fills only the
+**structure-derived k-path** (`&param_interpolation`'s high-symmetry points);
+all physics — including **`N_wannier`** (the number of target Wannier functions,
+a user choice such as t2g = 3, which is NOT the full orbital count), the energy
+windows, `dense`, and the cRPA parameters — comes from a template / `content`.
+Initial guesses use **SCDM** (`N_initial_guess = 0`), so no manual Gaussian
+projection block is emitted.
 
 Scope: the QE target stays unchanged; `respack` reuses it for QE-mode tasks.
 
@@ -20,11 +22,14 @@ Scope: the QE target stays unchanged; `respack` reuses it for QE-mode tasks.
 - Targets are dispatched in `main.py` via `normalize_target` + a `Struct2X`
   class; `input_validator.TARGETS` holds per-target aliases/required/allowed
   keys. Each `cif2x` run uses ONE target, but iterates a `tasks:` list.
-- `Struct2QE` already computes the Wannier counts: `_find_nbnd_info`
-  (`struct2qe.py:179-204`) sets `self.num_wann`, `self.nexclude`,
-  `self.num_bands` from `pp_file` `orbitals`/`nexclude` (loaded by
-  `_set_pseudo_info`). These are exactly `input.in`'s `N_wannier` and the QE
-  `nbnd` for the nscf step.
+- `Struct2QE._find_nbnd_info` (`struct2qe.py:179-204`) computes `num_wann` from
+  `pp_file` `orbitals` (s/p/d/f → 1/3/5/7) for the QE `nbnd` of the nscf step.
+  This **orbital count is NOT** RESPACK's `N_wannier`: `N_wannier` is the number
+  of target Wannier functions (e.g. t2g = 3 for SrVO3, while V's `d` orbital
+  count is 5 — see `samples/srvo3_6x6x6/input.in` `N_wannier=3`). So `N_wannier`
+  is a user-specified physics value, NOT auto-derived; `Struct2RESPACK` does not
+  need the pp table or `num_wann`. (`Struct2QE` keeps `_find_nbnd_info` unchanged
+  for the nscf `nbnd`.)
 - `cards._generate_band_path` builds a high-symmetry path from pymatgen
   `HighSymmKpath` (added for `bands`); `input.in`'s `&param_interpolation`
   block needs the same high-symmetry points (without per-segment divisions).
@@ -64,15 +69,12 @@ Scope: the QE target stays unchanged; `respack` reuses it for QE-mode tasks.
   after the namelists (token-level: the content `f90nml` did not consume, not a
   raw `/` string search). cif2x generates ALL non-namelist blocks (the k-coords
   block) itself, so a template must not carry a Gaussian or k-path block.
-- **Spin scope (v1):** `spinor_factor` comes from a **dedicated respack task
-  field `spinor`** (bool, default `false` → factor 1; `true` → factor 2), NOT
-  from a QE `&system` block (which must not appear in `input.in`). A spin-polarised
-  `nspin = 2` (LSDA) respack configuration is **rejected** with
-  `InputValidationError` (the split `input.in.up`/`.dn` is out of scope); the docs
-  require `spinor` to match the QE nscf task.
-- Wannier-count computation is **factored into a neutral shared helper**
-  (`src/cif2x/wannier.py`, not under `cif2x/qe/`) so QE and RESPACK produce
-  identical `num_wann`/`nexclude`.
+- **`N_wannier` is user-specified physics** (template/content), validated as a
+  present positive integer. cif2x does NOT auto-derive it (the orbital count is
+  not the target-Wannier count; see Background). Consequently `Struct2RESPACK`
+  needs no pseudopotential table, no `num_wann`, and no spin/SOC field — those
+  concern only the QE nscf `nbnd`, which `Struct2QE` already handles. (LSDA split
+  `input.in.up`/`.dn` is out of scope; v1 emits a single `input.in`.)
 
 ## RESPACK `input.in` format (resolved via cross-check of the reference parser)
 
@@ -112,37 +114,13 @@ break.
 
 ## Components
 
-### 1. Shared Wannier-count helper
-
-Extract the `num_wann`/`nexclude` computation currently inside
-`Struct2QE._find_nbnd_info` into a reusable function in a **neutral module**
-`src/cif2x/wannier.py` (NOT `cif2x/qe/`, so RESPACK does not depend on the QE
-namespace):
-
-```
-wannier_counts(composition: Mapping[str, int], pp_list, *, spinor_factor: int)
-    -> {"num_wann", "nexclude", "num_bands", "nbnd"}
-```
-
-- `composition` = per-element atom counts (e.g. `{"Sr":1,"V":1,"O":3}`); `pp_list`
-  is the pp table keyed by element symbol (the existing `Struct2QE.pp_list`).
-- Formula (verbatim from current `_find_nbnd_info`,
-  `struct2qe.py:188-203`): `nexclude = Σ_element count·pp[el].nexclude · sf`;
-  `num_wann = Σ_element count·(Σ orbital_degeneracy) · sf`;
-  `num_bands = num_wann*2 + (num_wann//2 + (num_wann//2)%2)`;
-  `nbnd = nexclude + num_bands`; where `sf = spinor_factor`.
-- A shared **pp loader** (thin extraction of `Struct2QE._set_pseudo_info`) returns
-  this `pp_list`; both QE and RESPACK use it. Missing `orbitals`/`nexclude`
-  columns raise `InputValidationError`.
-
-`Struct2QE._find_nbnd_info` calls `wannier_counts` (behavior unchanged — covered
-by existing QE tests); `Struct2RESPACK` calls it for `N_wannier` with
-`spinor_factor` from the task's `spinor` field.
-
-### 2. `Struct2RESPACK` (`src/cif2x/struct2respack.py`)
+### 1. `Struct2RESPACK` (`src/cif2x/struct2respack.py`)
 
 `__init__(params, struct)` then `write_input(output_file, output_dir, dry_run=False)`,
 matching the other generators (and supporting `--dry-run` via `utils.dryrun_emit`).
+No pseudopotential/`num_wann`/spin handling is needed — `N_wannier` is user
+physics, so this generator only merges the template, validates the physics it
+must, and appends the auto-generated k-path.
 
 Build `input.in`:
 1. Load the RESPACK template (`params["template"]`, namelist-only) with `f90nml`;
@@ -151,16 +129,14 @@ Build `input.in`:
    `deepupdate`). Namelist keys are case-insensitive (f90nml lowercases them);
    internal handling is lowercase and the rendered output uses lowercase keys
    (RESPACK reads keys case-insensitively, per the reference parser's `.lower()`).
-2. Resolve pseudopotential / orbital info via the shared pp loader, reading
-   `pp_file`/`pseudo_dir` from the **shared `optional:` block** (same source as QE
-   tasks; injected per-task by `deepupdate`). Determine `spinor_factor` from the
-   task's `spinor` field (default 1; `true` ⇒ 2); reject `nspin = 2`
-   (`InputValidationError`). Compute `num_wann` via `wannier_counts`.
-3. Auto-fill:
-   - `&param_wannier`: `N_wannier = num_wann`; force `N_initial_guess = 0` (SCDM)
-     and reject a template/content nonzero `N_initial_guess` or Gaussian block
-     with `InputValidationError`. `Lower_energy_window`/`Upper_energy_window` come
-     from template/content and are **validated** (both present, numeric,
+2. **Validate `&param_wannier.N_wannier`**: present and a positive integer
+   (`InputValidationError` otherwise) — it is user physics, never auto-derived.
+3. Auto-fill / validate:
+   - `&param_wannier`: force `N_initial_guess = 0` (SCDM) and reject a
+     template/content nonzero `N_initial_guess` or Gaussian block
+     (`InputValidationError`). `N_wannier` is taken from template/content
+     (validated in step 2). `Lower_energy_window`/`Upper_energy_window` come from
+     template/content and are **validated** (both present, numeric,
      `lower < upper`), else `InputValidationError`.
    - `&param_interpolation`: `dense` from template/content, validated as three
      ints (scalar → `(n,n,n)` or a 3-list); no invented physics default. Reject a
@@ -179,7 +155,7 @@ Build `input.in`:
    ignores). Surface pymatgen's "path may be incorrect" warning through the logger
    (as the QE bands path does) when the cell is non-standard.
 
-### 3. Dispatch + validation
+### 2. Dispatch + validation
 
 - `main._run`: when `target == "respack"`, select the generator per task:
   `mode in {"scf","nscf","bands"} → Struct2QE`, `mode == "respack" →
@@ -190,13 +166,12 @@ Build `input.in`:
 - `input_validator` validates respack tasks **per mode**: `scf`/`nscf`/`bands`
   tasks must satisfy the existing QE task schema (so QE required/allowed keys still
   apply), and a `mode: respack` task uses the RESPACK schema (allowed:
-  `mode`, `template`, `content`, `output_file`, `output_dir`, `optional`,
-  `spinor`; required: `mode`, `output_file`, `template`). Any other mode →
-  `InputValidationError`. `pp_file`/`pseudo_dir` are read from the merged
-  `optional` (a task-local `optional` overrides the shared top-level one via the
-  existing `deepupdate` precedence).
+  `mode`, `template`, `content`, `output_file`, `output_dir`, `optional`;
+  required: `mode`, `output_file`, `template`). Any other mode →
+  `InputValidationError`. (The respack task needs no pseudopotential keys —
+  `N_wannier` is user physics, not derived from `pp_file`.)
 
-### 4. QE side (no new code, but documented requirements)
+### 3. QE side (no new code, but documented requirements)
 
 The `scf`/`nscf`/`bands` tasks are ordinary `Struct2QE` tasks. For RESPACK the
 nscf task uses `K_POINTS` `crystal` (uniform explicit mesh, already supported)
@@ -217,11 +192,9 @@ possible follow-up.)
 - `structure.use_primitive` is false or `structure.use_ibrav` is true under
   `-t respack` → `InputValidationError` (the `HighSymmKpath` path requires the
   standardized primitive cell; a mismatched basis is a silent physics error).
-- Missing `pp_file`/`orbitals` columns when `num_wann` is needed →
-  `InputValidationError` (the shared pp loader/helper raises it).
+- `N_wannier` absent or not a positive integer → `InputValidationError`.
 - `N_initial_guess != 0` or a Gaussian block in template/content →
   `InputValidationError` (v1 is SCDM-only).
-- `nspin = 2` in a respack task → `InputValidationError` (LSDA out of scope).
 - Missing/invalid energy windows (`Lower`/`Upper` absent, non-numeric, or
   `lower >= upper`) → `InputValidationError`.
 - `dense` not three ints → `InputValidationError`.
@@ -229,25 +202,21 @@ possible follow-up.)
 
 ## Testing (network-free where possible)
 
-- **Shared helper:** `wannier_counts` returns the expected
-  `num_wann`/`nexclude`/`num_bands`/`nbnd` for a small species list + a stub pp
-  table, for both `spinor_factor=1` and `2`; existing QE `nbnd` tests still pass
-  (behavior unchanged).
 - **Struct2RESPACK render (golden-style):** with a small structure
-  (`use_primitive=True`, `use_ibrav=False`), a minimal RESPACK template, and a
-  stub pp table, render `input.in` and **parse it back** (f90nml for the
-  namelists + a small reader for the k-coords block) to assert: `N_wannier` =
-  computed num_wann; `N_initial_guess = 0` and no Gaussian lines; `N_sym_points`
-  equals the per-segment lengths from `HighSymmKpath` and the coords block has
-  that many lines per segment; `dense` and the windows pass through. Include a
-  multi-segment structure (e.g. simple cubic) so the segment list is exercised.
-  Use `pytest.importorskip("pymatgen")`.
-- **Spin:** `spinor: true` doubles `num_wann`/`N_wannier` vs the default; assert
-  both.
+  (`use_primitive=True`, `use_ibrav=False`) and a minimal RESPACK template that
+  sets `N_wannier`/windows/`dense`, render `input.in` and **parse it back**
+  (f90nml for the namelists + a small reader for the k-coords block) to assert:
+  `N_wannier` is the user value (passed through unchanged); `N_initial_guess = 0`
+  and no Gaussian lines; `N_sym_points` equals the per-segment lengths from
+  `HighSymmKpath` and the coords block has that many lines per segment; `dense`
+  and the windows pass through. Include a multi-segment structure (e.g. simple
+  cubic) so the segment list is exercised. Use `pytest.importorskip("pymatgen")`.
 - **Template contract:** a template with a trailing non-namelist line, or a
   non-`param_*` namelist such as `&system`, is rejected.
-- **Validation/error paths:** nonzero `N_initial_guess`, missing window,
-  `lower >= upper`, bad `dense`, `nspin = 2` each raise `InputValidationError`.
+- **Validation/error paths:** missing/non-positive `N_wannier`, nonzero
+  `N_initial_guess`, missing window, `lower >= upper`, bad `dense`, nonzero
+  `reading_sk_format`, and `use_primitive=False`/`use_ibrav=True` each raise
+  `InputValidationError`.
 - **Dispatch:** `-t respack` routes a `mode: scf` task to `Struct2QE` and a
   `mode: respack` task to `Struct2RESPACK` (monkeypatch both, assert each
   `write_input` is called for the right task); `mode: relax` (and unknown) raise.
@@ -295,10 +264,13 @@ possible follow-up.)
 
 ## Open items to resolve in the plan
 
-- The exact mechanics of extracting the shared pp loader from
-  `Struct2QE._set_pseudo_info` (which attributes it must keep populating on
-  `Struct2QE` for backward compatibility) — QE behavior must stay unchanged
-  (covered by existing QE tests).
-- Whether `HighSymmKpath` segment labels (e.g. `\Gamma`) are emitted verbatim as
-  inline comments or normalized to ASCII (comments are ignored by RESPACK, so
-  either is acceptable; pick one in the plan).
+- `HighSymmKpath` segment labels (e.g. `\Gamma`) — emit verbatim as inline
+  comments (chosen: verbatim, since RESPACK ignores comments); confirm the
+  comment syntax `! label` is accepted by the reference parser's line reader.
+- Whether v1 ships a runnable `sample/cif2x/respack/<case>/` directory or
+  docs-only inline examples (decide in the plan; a runnable sample strengthens
+  coverage but needs a structure file + pp CSV + templates).
+
+(The shared Wannier-count helper and pp-loader extraction are NO LONGER part of
+this feature — `N_wannier` is user-specified, so `Struct2QE._find_nbnd_info`
+stays untouched and `Struct2RESPACK` needs no pp table.)

--- a/docs/superpowers/specs/2026-06-30-respack-target-design.md
+++ b/docs/superpowers/specs/2026-06-30-respack-target-design.md
@@ -57,11 +57,13 @@ Scope: the QE target stays unchanged; `respack` reuses it for QE-mode tasks.
   Gaussian block (v1). If the template/content supplies a nonzero
   `N_initial_guess` or a Gaussian projection block, that is **rejected** with
   `InputValidationError` (v1 is SCDM-only; no silent override).
-- **Template contract (v1): namelist-only.** A RESPACK template contains only
-  `&param_*` namelists (parsed by `f90nml`). Any non-blank, non-comment line
-  after the last namelist's `/` is rejected with `InputValidationError` — cif2x
-  generates ALL non-namelist blocks (the k-coords block) itself, so a template
-  must not carry a Gaussian or k-path block.
+- **Template contract (v1): `&param_*` namelists only.** A RESPACK template is
+  parsed with `f90nml`; cif2x then rejects (`InputValidationError`): (a) any
+  namelist whose name is not a RESPACK `param_*` block (so an accidental QE
+  `&system` is caught), and (b) any unparsed non-blank/non-comment remainder
+  after the namelists (token-level: the content `f90nml` did not consume, not a
+  raw `/` string search). cif2x generates ALL non-namelist blocks (the k-coords
+  block) itself, so a template must not carry a Gaussian or k-path block.
 - **Spin scope (v1):** `spinor_factor` comes from a **dedicated respack task
   field `spinor`** (bool, default `false` → factor 1; `true` → factor 2), NOT
   from a QE `&system` block (which must not appear in `input.in`). A spin-polarised
@@ -161,17 +163,21 @@ Build `input.in`:
      from template/content and are **validated** (both present, numeric,
      `lower < upper`), else `InputValidationError`.
    - `&param_interpolation`: `dense` from template/content, validated as three
-     ints (scalar → `(n,n,n)` or a 3-list); no invented physics default. The
-     k-path comes from `HighSymmKpath(struct.structure)`: emit
+     ints (scalar → `(n,n,n)` or a 3-list); no invented physics default. Reject a
+     nonzero `reading_sk_format` (cif2x only emits format 0). The k-path comes from
+     `HighSymmKpath(struct.structure)`: emit
      `N_sym_points = [len(seg) for seg in kpath["path"]]` (one entry per disjoint
-     segment, each `>= 2`) and the segment-by-segment coords block.
+     segment, each `>= 2`; canonical output — no Fortran trailing-zero padding) and
+     the segment-by-segment coords block.
    - `&param_chiqw` / `&param_calc_int` / `&param_visualization`: passthrough from
      template/content.
-4. Render (format resolved above): write the `&param_*` namelists in RESPACK
-   order; after `&param_interpolation`'s `/`, append the multi-segment k-coords
-   block (format 0): per segment, one `kx ky kz  ! label` line per high-symmetry
-   point (fractional coords). Surface pymatgen's "path may be incorrect" warning
-   through the logger (as the QE bands path does) when the cell is non-standard.
+4. Render (format resolved above): `f90nml` cannot interleave raw text between
+   namelists, so write each `&param_*` namelist individually in RESPACK order and
+   **append the k-coords block immediately after the `&param_interpolation`
+   namelist's `/`**: per segment, one `kx ky kz  ! label` line per high-symmetry
+   point (fractional coords; labels emitted verbatim — they are comments RESPACK
+   ignores). Surface pymatgen's "path may be incorrect" warning through the logger
+   (as the QE bands path does) when the cell is non-standard.
 
 ### 3. Dispatch + validation
 
@@ -186,7 +192,9 @@ Build `input.in`:
   apply), and a `mode: respack` task uses the RESPACK schema (allowed:
   `mode`, `template`, `content`, `output_file`, `output_dir`, `optional`,
   `spinor`; required: `mode`, `output_file`, `template`). Any other mode →
-  `InputValidationError`.
+  `InputValidationError`. `pp_file`/`pseudo_dir` are read from the merged
+  `optional` (a task-local `optional` overrides the shared top-level one via the
+  existing `deepupdate` precedence).
 
 ### 4. QE side (no new code, but documented requirements)
 
@@ -203,8 +211,12 @@ possible follow-up.)
 ## Error handling
 
 - `respack` task with an unrecognized/unsupported `mode` → `InputValidationError`.
-- Template with non-blank/non-comment content after the last namelist →
-  `InputValidationError` (v1 templates are namelist-only).
+- Template with a non-`param_*` namelist (e.g. `&system`) or unparsed
+  non-blank/non-comment remainder → `InputValidationError` (namelist-only).
+- `reading_sk_format != 0` in template/content → `InputValidationError`.
+- `structure.use_primitive` is false or `structure.use_ibrav` is true under
+  `-t respack` → `InputValidationError` (the `HighSymmKpath` path requires the
+  standardized primitive cell; a mismatched basis is a silent physics error).
 - Missing `pp_file`/`orbitals` columns when `num_wann` is needed →
   `InputValidationError` (the shared pp loader/helper raises it).
 - `N_initial_guess != 0` or a Gaussian block in template/content →
@@ -232,7 +244,8 @@ possible follow-up.)
   Use `pytest.importorskip("pymatgen")`.
 - **Spin:** `spinor: true` doubles `num_wann`/`N_wannier` vs the default; assert
   both.
-- **Template contract:** a template with a trailing non-namelist line is rejected.
+- **Template contract:** a template with a trailing non-namelist line, or a
+  non-`param_*` namelist such as `&system`, is rejected.
 - **Validation/error paths:** nonzero `N_initial_guess`, missing window,
   `lower >= upper`, bad `dense`, `nspin = 2` each raise `InputValidationError`.
 - **Dispatch:** `-t respack` routes a `mode: scf` task to `Struct2QE` and a
@@ -260,9 +273,10 @@ possible follow-up.)
 
 - **Reciprocal-basis match:** `HighSymmKpath` coordinates are in the standardized
   primitive reciprocal basis, so the RESPACK path is only consistent with a
-  primitive cell. respack targets `use_primitive: true` (and `use_ibrav: false`),
-  same as the QE bands path; pymatgen's "path may be incorrect" warning is
-  surfaced for non-standard cells.
+  primitive cell. respack **requires** `use_primitive: true` and
+  `use_ibrav: false` (enforced with `InputValidationError`); pymatgen's "path may
+  be incorrect" warning is additionally surfaced for any residual non-standard
+  cell.
 - **Fortran-RESPACK incompatibility:** SCDM (`N_initial_guess = 0`, no Gaussian
   block) is supported by `respack-wannier-py`; the Fortran `calc_wannier` would
   reject it. Stated in the docs.

--- a/docs/superpowers/specs/2026-06-30-respack-target-design.md
+++ b/docs/superpowers/specs/2026-06-30-respack-target-design.md
@@ -57,10 +57,17 @@ Scope: the QE target stays unchanged; `respack` reuses it for QE-mode tasks.
   Gaussian block (v1). If the template/content supplies a nonzero
   `N_initial_guess` or a Gaussian projection block, that is **rejected** with
   `InputValidationError` (v1 is SCDM-only; no silent override).
-- **Spin scope (v1):** `Struct2RESPACK` derives `spinor_factor` from **its own
-  task's** `content.system` flags (`noncolin` / `lspinorb` → 2; else 1; default
-  non-spinor). It does NOT read other (QE) tasks. The docs require these to match
-  the QE nscf task. LSDA split `input.in.up`/`.dn` is out of scope.
+- **Template contract (v1): namelist-only.** A RESPACK template contains only
+  `&param_*` namelists (parsed by `f90nml`). Any non-blank, non-comment line
+  after the last namelist's `/` is rejected with `InputValidationError` — cif2x
+  generates ALL non-namelist blocks (the k-coords block) itself, so a template
+  must not carry a Gaussian or k-path block.
+- **Spin scope (v1):** `spinor_factor` comes from a **dedicated respack task
+  field `spinor`** (bool, default `false` → factor 1; `true` → factor 2), NOT
+  from a QE `&system` block (which must not appear in `input.in`). A spin-polarised
+  `nspin = 2` (LSDA) respack configuration is **rejected** with
+  `InputValidationError` (the split `input.in.up`/`.dn` is out of scope); the docs
+  require `spinor` to match the QE nscf task.
 - Wannier-count computation is **factored into a neutral shared helper**
   (`src/cif2x/wannier.py`, not under `cif2x/qe/`) so QE and RESPACK produce
   identical `num_wann`/`nexclude`.
@@ -108,11 +115,27 @@ break.
 Extract the `num_wann`/`nexclude` computation currently inside
 `Struct2QE._find_nbnd_info` into a reusable function in a **neutral module**
 `src/cif2x/wannier.py` (NOT `cif2x/qe/`, so RESPACK does not depend on the QE
-namespace), e.g.
-`wannier_counts(species, pp_list, *, spinor_factor) -> {num_wann, nexclude, num_bands, nbnd}`.
-`Struct2QE._find_nbnd_info` calls it (behavior unchanged — covered by existing QE
-tests); `Struct2RESPACK` calls it for `N_wannier`. Missing `orbitals`/`nexclude`
-columns raise `InputValidationError` (consistent clean-exit handling).
+namespace):
+
+```
+wannier_counts(composition: Mapping[str, int], pp_list, *, spinor_factor: int)
+    -> {"num_wann", "nexclude", "num_bands", "nbnd"}
+```
+
+- `composition` = per-element atom counts (e.g. `{"Sr":1,"V":1,"O":3}`); `pp_list`
+  is the pp table keyed by element symbol (the existing `Struct2QE.pp_list`).
+- Formula (verbatim from current `_find_nbnd_info`,
+  `struct2qe.py:188-203`): `nexclude = Σ_element count·pp[el].nexclude · sf`;
+  `num_wann = Σ_element count·(Σ orbital_degeneracy) · sf`;
+  `num_bands = num_wann*2 + (num_wann//2 + (num_wann//2)%2)`;
+  `nbnd = nexclude + num_bands`; where `sf = spinor_factor`.
+- A shared **pp loader** (thin extraction of `Struct2QE._set_pseudo_info`) returns
+  this `pp_list`; both QE and RESPACK use it. Missing `orbitals`/`nexclude`
+  columns raise `InputValidationError`.
+
+`Struct2QE._find_nbnd_info` calls `wannier_counts` (behavior unchanged — covered
+by existing QE tests); `Struct2RESPACK` calls it for `N_wannier` with
+`spinor_factor` from the task's `spinor` field.
 
 ### 2. `Struct2RESPACK` (`src/cif2x/struct2respack.py`)
 
@@ -120,12 +143,17 @@ columns raise `InputValidationError` (consistent clean-exit handling).
 matching the other generators (and supporting `--dry-run` via `utils.dryrun_emit`).
 
 Build `input.in`:
-1. Load the RESPACK template (`params["template"]`) namelists with `f90nml`;
-   deep-merge `params["content"]` on top (reuse `deepupdate`).
-2. Resolve pseudopotential / orbital info via a shared pp loader (extracted from
-   `Struct2QE._set_pseudo_info`, see Open items) and determine `spinor_factor`
-   from this task's `content.system` (`noncolin`/`lspinorb` ⇒ 2, else 1); compute
-   `num_wann` via the shared helper.
+1. Load the RESPACK template (`params["template"]`, namelist-only) with `f90nml`;
+   reject any non-blank/non-comment line after the last namelist
+   (`InputValidationError`). Deep-merge `params["content"]` on top (reuse
+   `deepupdate`). Namelist keys are case-insensitive (f90nml lowercases them);
+   internal handling is lowercase and the rendered output uses lowercase keys
+   (RESPACK reads keys case-insensitively, per the reference parser's `.lower()`).
+2. Resolve pseudopotential / orbital info via the shared pp loader, reading
+   `pp_file`/`pseudo_dir` from the **shared `optional:` block** (same source as QE
+   tasks; injected per-task by `deepupdate`). Determine `spinor_factor` from the
+   task's `spinor` field (default 1; `true` ⇒ 2); reject `nspin = 2`
+   (`InputValidationError`). Compute `num_wann` via `wannier_counts`.
 3. Auto-fill:
    - `&param_wannier`: `N_wannier = num_wann`; force `N_initial_guess = 0` (SCDM)
      and reject a template/content nonzero `N_initial_guess` or Gaussian block
@@ -153,11 +181,12 @@ Build `input.in`:
   target 'respack'")` (relax/vc-relax/dos are NOT accepted under respack). Other
   targets keep the single-generator loop. Factor the per-task body (params build,
   optional injection, write_input) so both paths share it.
-- `input_validator.TARGETS["respack"]`: `aliases = ("respack",)`;
-  per-task allowed keys = QE allowed ∪ respack-specific (`template`, `content`,
-  `output_file`, `output_dir`, `mode`, `optional`); required = `mode`,
-  `output_file`. Mode legality (`scf`/`nscf`/`bands`/`respack` only) is checked at
-  dispatch.
+- `input_validator` validates respack tasks **per mode**: `scf`/`nscf`/`bands`
+  tasks must satisfy the existing QE task schema (so QE required/allowed keys still
+  apply), and a `mode: respack` task uses the RESPACK schema (allowed:
+  `mode`, `template`, `content`, `output_file`, `output_dir`, `optional`,
+  `spinor`; required: `mode`, `output_file`, `template`). Any other mode →
+  `InputValidationError`.
 
 ### 4. QE side (no new code, but documented requirements)
 
@@ -165,17 +194,22 @@ The `scf`/`nscf`/`bands` tasks are ordinary `Struct2QE` tasks. For RESPACK the
 nscf task uses `K_POINTS` `crystal` (uniform explicit mesh, already supported)
 and `nbnd` is auto-filled from `num_bands` (already supported). **`qe2respack`
 requires the nscf run to set `nosym = .true.` and `noinv = .true.`** — the sample
-`input.yaml` sets these in the nscf task's `content.system`, and the docs call it
-out. (v1 documents it rather than auto-injecting, to avoid surprising the QE
-path; auto-injection is a possible follow-up.)
+`input.yaml` sets these in the nscf task's `content.system`. When the respack
+target sees a `mode: nscf` task whose `content.system` lacks `nosym`/`noinv`
+(or sets them false), it emits a `logger.warning` (not an error — the user may
+have reasons), and the docs call out the requirement. (Auto-injection is a
+possible follow-up.)
 
 ## Error handling
 
 - `respack` task with an unrecognized/unsupported `mode` → `InputValidationError`.
+- Template with non-blank/non-comment content after the last namelist →
+  `InputValidationError` (v1 templates are namelist-only).
 - Missing `pp_file`/`orbitals` columns when `num_wann` is needed →
   `InputValidationError` (the shared pp loader/helper raises it).
 - `N_initial_guess != 0` or a Gaussian block in template/content →
   `InputValidationError` (v1 is SCDM-only).
+- `nspin = 2` in a respack task → `InputValidationError` (LSDA out of scope).
 - Missing/invalid energy windows (`Lower`/`Upper` absent, non-numeric, or
   `lower >= upper`) → `InputValidationError`.
 - `dense` not three ints → `InputValidationError`.
@@ -196,8 +230,11 @@ path; auto-injection is a possible follow-up.)
   that many lines per segment; `dense` and the windows pass through. Include a
   multi-segment structure (e.g. simple cubic) so the segment list is exercised.
   Use `pytest.importorskip("pymatgen")`.
+- **Spin:** `spinor: true` doubles `num_wann`/`N_wannier` vs the default; assert
+  both.
+- **Template contract:** a template with a trailing non-namelist line is rejected.
 - **Validation/error paths:** nonzero `N_initial_guess`, missing window,
-  `lower >= upper`, bad `dense` each raise `InputValidationError`.
+  `lower >= upper`, bad `dense`, `nspin = 2` each raise `InputValidationError`.
 - **Dispatch:** `-t respack` routes a `mode: scf` task to `Struct2QE` and a
   `mode: respack` task to `Struct2RESPACK` (monkeypatch both, assert each
   `write_input` is called for the right task); `mode: relax` (and unknown) raise.
@@ -244,7 +281,10 @@ path; auto-injection is a possible follow-up.)
 
 ## Open items to resolve in the plan
 
-- Whether the shared pp loader is a thin extraction of
-  `Struct2QE._set_pseudo_info` (composition) or a new function in
-  `cif2x/wannier.py` alongside `wannier_counts`; either way, QE behavior must stay
-  unchanged (covered by existing QE tests).
+- The exact mechanics of extracting the shared pp loader from
+  `Struct2QE._set_pseudo_info` (which attributes it must keep populating on
+  `Struct2QE` for backward compatibility) — QE behavior must stay unchanged
+  (covered by existing QE tests).
+- Whether `HighSymmKpath` segment labels (e.g. `\Gamma`) are emitted verbatim as
+  inline comments or normalized to ASCII (comments are ignored by RESPACK, so
+  either is acceptable; pick one in the plan).

--- a/docs/superpowers/specs/2026-06-30-respack-target-design.md
+++ b/docs/superpowers/specs/2026-06-30-respack-target-design.md
@@ -41,26 +41,78 @@ Scope: the QE target stays unchanged; `respack` reuses it for QE-mode tasks.
 
 ## Decisions
 
-- `-t respack` routes **per task by `mode`**: QE modes
-  (`scf`/`nscf`/`bands`/`relax`/`vc-relax`/`dos`) → `Struct2QE`; `mode: respack`
-  → new `Struct2RESPACK`; anything else → `InputValidationError`.
+- **Target tool = `respack-wannier-py` (the Python port)**, not Fortran RESPACK.
+  v1's SCDM/`N_initial_guess = 0` (no Gaussian block) is supported by the port
+  per `input_parser.py:367-372`; the Fortran `calc_wannier` would reject it. This
+  assumption is stated in the docs.
+- `-t respack` routes **per task by `mode`**: the RESPACK workflow QE modes
+  **`scf` / `nscf` / `bands`** → `Struct2QE`; `mode: respack` → new
+  `Struct2RESPACK`; any other mode (incl. `relax`/`vc-relax`/`dos`) →
+  `InputValidationError` (respack's surface is intentionally narrowed to the
+  workflow it consumes).
 - `input.in` is built **template + content merge** (like QE): the template holds
   the `&param_*` namelists (physics); cif2x fills the structure-derived blanks
-  and appends the auto-generated k-path block.
-- **SCDM** initial guess: set `N_initial_guess = 0`, emit no Gaussian block (v1).
-- Wannier-count computation is **factored into a shared helper** so QE and
-  RESPACK produce identical `num_wann`/`nexclude`.
+  and appends the auto-generated multi-segment k-path block.
+- **SCDM** initial guess: cif2x always sets `N_initial_guess = 0` and emits no
+  Gaussian block (v1). If the template/content supplies a nonzero
+  `N_initial_guess` or a Gaussian projection block, that is **rejected** with
+  `InputValidationError` (v1 is SCDM-only; no silent override).
+- **Spin scope (v1):** `Struct2RESPACK` derives `spinor_factor` from **its own
+  task's** `content.system` flags (`noncolin` / `lspinorb` → 2; else 1; default
+  non-spinor). It does NOT read other (QE) tasks. The docs require these to match
+  the QE nscf task. LSDA split `input.in.up`/`.dn` is out of scope.
+- Wannier-count computation is **factored into a neutral shared helper**
+  (`src/cif2x/wannier.py`, not under `cif2x/qe/`) so QE and RESPACK produce
+  identical `num_wann`/`nexclude`.
+
+## RESPACK `input.in` format (resolved via cross-check of the reference parser)
+
+From `respack-wannier-py` `input_parser.py:108-230` (`parse_band_path`,
+`_read_band_path_coords`) and the `samples/*/input.in` corpus:
+
+- `&param_interpolation` supports **multiple disjoint paths**. `N_sym_points` is
+  a **list** — one positive integer per path (number of high-symmetry points on
+  that path, each `>= 2`), with trailing-zero padding (Fortran fixed array up to
+  10). A scalar means a single path.
+- The k-coords block follows the `&param_interpolation` `/` (default
+  `reading_sk_format = 0`): for each path, for each high-symmetry point, one line
+  of three fractional (crystal) coordinates `kx ky kz`; an inline `! label`
+  comment is allowed and ignored by the parser. cif2x emits format 0.
+- `dense` is three integers (scalar → `(n,n,n)`, or a 3-list); `Ndiv` defaults to
+  40 if omitted (left to template/content).
+- `&param_wannier`: `N_wannier`, `Lower_energy_window`, `Upper_energy_window`,
+  `N_initial_guess` (0 ⇒ SCDM, no Gaussian block).
+
+Example (single path, srvo3-style):
+
+```
+&param_interpolation
+dense = 8, 8, 8
+N_sym_points=5/
+0.50 0.50 0.50  ! R
+0.00 0.00 0.00  ! G
+0.50 0.00 0.00  ! X
+0.50 0.50 0.00  ! M
+0.00 0.00 0.00  ! G
+```
+
+For a structure whose `HighSymmKpath` path has two disjoint segments
+(e.g. `[[Γ,X,M,Γ,R,X],[M,R]]`), emit `N_sym_points=6,2/` then the 6 coords of
+the first segment followed by the 2 of the second — no interpolation bridges the
+break.
 
 ## Components
 
 ### 1. Shared Wannier-count helper
 
 Extract the `num_wann`/`nexclude` computation currently inside
-`Struct2QE._find_nbnd_info` into a reusable function (new
-`src/cif2x/wannier.py`, or a function in `cif2x/qe/tools.py`), e.g.
+`Struct2QE._find_nbnd_info` into a reusable function in a **neutral module**
+`src/cif2x/wannier.py` (NOT `cif2x/qe/`, so RESPACK does not depend on the QE
+namespace), e.g.
 `wannier_counts(species, pp_list, *, spinor_factor) -> {num_wann, nexclude, num_bands, nbnd}`.
-`Struct2QE._find_nbnd_info` calls it (behavior unchanged — covered by existing
-QE tests); `Struct2RESPACK` calls it for `N_wannier`.
+`Struct2QE._find_nbnd_info` calls it (behavior unchanged — covered by existing QE
+tests); `Struct2RESPACK` calls it for `N_wannier`. Missing `orbitals`/`nexclude`
+columns raise `InputValidationError` (consistent clean-exit handling).
 
 ### 2. `Struct2RESPACK` (`src/cif2x/struct2respack.py`)
 
@@ -70,90 +122,129 @@ matching the other generators (and supporting `--dry-run` via `utils.dryrun_emit
 Build `input.in`:
 1. Load the RESPACK template (`params["template"]`) namelists with `f90nml`;
    deep-merge `params["content"]` on top (reuse `deepupdate`).
-2. Resolve pseudopotential / orbital info (reuse `Struct2QE._set_pseudo_info`
-   logic or share it) and compute `num_wann` via the shared helper.
+2. Resolve pseudopotential / orbital info via a shared pp loader (extracted from
+   `Struct2QE._set_pseudo_info`, see Open items) and determine `spinor_factor`
+   from this task's `content.system` (`noncolin`/`lspinorb` ⇒ 2, else 1); compute
+   `num_wann` via the shared helper.
 3. Auto-fill:
-   - `&param_wannier`: `N_wannier = num_wann`; `N_initial_guess = 0` (SCDM);
-     `Lower_energy_window` / `Upper_energy_window` from content (physics).
-   - `&param_interpolation`: `dense` from content (or a k-resolution default);
-     `N_sym_points = <number of high-symmetry points>`.
-   - `&param_chiqw` / `&param_calc_int` / `&param_visualization`: passthrough
-     from template/content.
-4. Render: write the `&param_*` namelists in RESPACK order, and **after
-   `&param_interpolation`'s `/`, append the high-symmetry k-coords block** — one
-   line per point `kx ky kz  ! label`, count = `N_sym_points`, from
-   `HighSymmKpath`. (Cross-check the exact RESPACK `m_rdinput` trailing-block
-   format/order against the reference `respack-wannier-py` `input_parser.py`
-   during implementation.)
+   - `&param_wannier`: `N_wannier = num_wann`; force `N_initial_guess = 0` (SCDM)
+     and reject a template/content nonzero `N_initial_guess` or Gaussian block
+     with `InputValidationError`. `Lower_energy_window`/`Upper_energy_window` come
+     from template/content and are **validated** (both present, numeric,
+     `lower < upper`), else `InputValidationError`.
+   - `&param_interpolation`: `dense` from template/content, validated as three
+     ints (scalar → `(n,n,n)` or a 3-list); no invented physics default. The
+     k-path comes from `HighSymmKpath(struct.structure)`: emit
+     `N_sym_points = [len(seg) for seg in kpath["path"]]` (one entry per disjoint
+     segment, each `>= 2`) and the segment-by-segment coords block.
+   - `&param_chiqw` / `&param_calc_int` / `&param_visualization`: passthrough from
+     template/content.
+4. Render (format resolved above): write the `&param_*` namelists in RESPACK
+   order; after `&param_interpolation`'s `/`, append the multi-segment k-coords
+   block (format 0): per segment, one `kx ky kz  ! label` line per high-symmetry
+   point (fractional coords). Surface pymatgen's "path may be incorrect" warning
+   through the logger (as the QE bands path does) when the cell is non-standard.
 
 ### 3. Dispatch + validation
 
 - `main._run`: when `target == "respack"`, select the generator per task:
-  `mode in _QE_MODES → Struct2QE`, `mode == "respack" → Struct2RESPACK`, else
-  `InputValidationError("task N: unknown mode '<m>' for target 'respack'")`.
-  Other targets keep the single-generator loop. Factor the per-task body
-  (params build, optional injection, write_input) so both paths share it.
+  `mode in {"scf","nscf","bands"} → Struct2QE`, `mode == "respack" →
+  Struct2RESPACK`, else `InputValidationError("task N: unknown mode '<m>' for
+  target 'respack'")` (relax/vc-relax/dos are NOT accepted under respack). Other
+  targets keep the single-generator loop. Factor the per-task body (params build,
+  optional injection, write_input) so both paths share it.
 - `input_validator.TARGETS["respack"]`: `aliases = ("respack",)`;
   per-task allowed keys = QE allowed ∪ respack-specific (`template`, `content`,
   `output_file`, `output_dir`, `mode`, `optional`); required = `mode`,
-  `output_file`. Mode legality (QE-mode vs `respack`) is checked at dispatch.
+  `output_file`. Mode legality (`scf`/`nscf`/`bands`/`respack` only) is checked at
+  dispatch.
 
-### 4. QE side (no new code)
+### 4. QE side (no new code, but documented requirements)
 
 The `scf`/`nscf`/`bands` tasks are ordinary `Struct2QE` tasks. For RESPACK the
 nscf task uses `K_POINTS` `crystal` (uniform explicit mesh, already supported)
-and `nbnd` is auto-filled from `num_bands` (already supported). Configuration
-lives in the sample `input.yaml`.
+and `nbnd` is auto-filled from `num_bands` (already supported). **`qe2respack`
+requires the nscf run to set `nosym = .true.` and `noinv = .true.`** — the sample
+`input.yaml` sets these in the nscf task's `content.system`, and the docs call it
+out. (v1 documents it rather than auto-injecting, to avoid surprising the QE
+path; auto-injection is a possible follow-up.)
 
 ## Error handling
 
-- `respack` task with an unrecognized `mode` → `InputValidationError` (clean exit).
-- Missing `pp_file`/`orbitals` when `num_wann` is needed → the existing
-  `Struct2QE` error path (reused), surfaced clearly.
+- `respack` task with an unrecognized/unsupported `mode` → `InputValidationError`.
+- Missing `pp_file`/`orbitals` columns when `num_wann` is needed →
+  `InputValidationError` (the shared pp loader/helper raises it).
+- `N_initial_guess != 0` or a Gaussian block in template/content →
+  `InputValidationError` (v1 is SCDM-only).
+- Missing/invalid energy windows (`Lower`/`Upper` absent, non-numeric, or
+  `lower >= upper`) → `InputValidationError`.
+- `dense` not three ints → `InputValidationError`.
 - Template parse failure → `InputValidationError` with the file name.
 
 ## Testing (network-free where possible)
 
-- **Shared helper:** `wannier_counts` returns the expected `num_wann`/`nexclude`
-  for a small species list + a stub pp table; existing QE `nbnd` tests still pass
+- **Shared helper:** `wannier_counts` returns the expected
+  `num_wann`/`nexclude`/`num_bands`/`nbnd` for a small species list + a stub pp
+  table, for both `spinor_factor=1` and `2`; existing QE `nbnd` tests still pass
   (behavior unchanged).
-- **Struct2RESPACK:** with a small structure (`use_ibrav=False`), a minimal
-  RESPACK template, and a stub pp table, assert the rendered `input.in` has
-  `N_wannier` = computed num_wann, `N_initial_guess = 0`, no Gaussian block, a
-  `&param_interpolation` k-coords block whose count matches the high-symmetry
-  points, and that template/content physics values pass through. Use
-  `pytest.importorskip("pymatgen")`.
+- **Struct2RESPACK render (golden-style):** with a small structure
+  (`use_primitive=True`, `use_ibrav=False`), a minimal RESPACK template, and a
+  stub pp table, render `input.in` and **parse it back** (f90nml for the
+  namelists + a small reader for the k-coords block) to assert: `N_wannier` =
+  computed num_wann; `N_initial_guess = 0` and no Gaussian lines; `N_sym_points`
+  equals the per-segment lengths from `HighSymmKpath` and the coords block has
+  that many lines per segment; `dense` and the windows pass through. Include a
+  multi-segment structure (e.g. simple cubic) so the segment list is exercised.
+  Use `pytest.importorskip("pymatgen")`.
+- **Validation/error paths:** nonzero `N_initial_guess`, missing window,
+  `lower >= upper`, bad `dense` each raise `InputValidationError`.
 - **Dispatch:** `-t respack` routes a `mode: scf` task to `Struct2QE` and a
   `mode: respack` task to `Struct2RESPACK` (monkeypatch both, assert each
-  `write_input` is called for the right task); an unknown mode raises.
-- **Validation:** respack target accepts the sample tasks; an unknown top-level
-  or task key is rejected.
+  `write_input` is called for the right task); `mode: relax` (and unknown) raise.
+- **Validation:** respack target accepts the sample tasks; unknown top-level/task
+  keys rejected.
 
 ## Documentation + sample
 
 - Command reference (en/ja): add `respack` to the targets list.
 - A new section / tutorial example showing the full chain `input.yaml`
   (`tasks:` = scf, nscf, bands QE tasks + a `mode: respack` task) plus a RESPACK
-  `input.in` template, and noting SCDM (`N_initial_guess = 0`) and that energy
-  windows / Ecut / flg_cRPA are user physics.
+  `input.in` template. Call out: SCDM (`N_initial_guess = 0`); energy windows /
+  Ecut / flg_cRPA are user physics; the nscf task must set
+  `nosym = .true.`/`noinv = .true.` (qe2respack); the documented run order
+  scf → nscf → `qe2respack` → `respack_wannier`; the target is the
+  `respack-wannier-py` port (SCDM); and `use_primitive: true` for a correct
+  k-path.
 - A `sample/cif2x/respack/<case>/` directory mirroring the existing samples
   (structure file + input.yaml + RESPACK template), if a runnable example is
   wanted (decide in the plan; may be docs-only inline like the sweep examples).
 
+## Risks (documented)
+
+- **Reciprocal-basis match:** `HighSymmKpath` coordinates are in the standardized
+  primitive reciprocal basis, so the RESPACK path is only consistent with a
+  primitive cell. respack targets `use_primitive: true` (and `use_ibrav: false`),
+  same as the QE bands path; pymatgen's "path may be incorrect" warning is
+  surfaced for non-standard cells.
+- **Fortran-RESPACK incompatibility:** SCDM (`N_initial_guess = 0`, no Gaussian
+  block) is supported by `respack-wannier-py`; the Fortran `calc_wannier` would
+  reject it. Stated in the docs.
+- **Directory/prefix alignment:** cif2x emits inputs only; the user must keep the
+  QE `prefix`/`outdir` and the `qe2respack`/`respack_wannier` working directories
+  consistent. The sample + docs show a consistent layout.
+
 ## Out of scope (v1)
 
 - Manual Gaussian initial-guess projections (SCDM only).
-- Spin-polarized split `input.in.up` / `input.in.dn` (LSDA) — note as a
-  follow-up.
-- `qe2respack` invocation (a runtime conversion step the user runs; cif2x only
-  emits inputs).
+- Spin-polarized split `input.in.up` / `input.in.dn` (LSDA) — follow-up.
+- `qe2respack` invocation and any execution orchestration (cif2x only emits
+  inputs; the run order scf→nscf→qe2respack→respack is documented, not executed).
 - Auto-deriving energy windows / cRPA parameters (physics; template/content).
-- Cross-tool orchestration beyond per-task routing within one `-t respack` run.
+- Auto-injecting nscf `nosym`/`noinv` (documented in the sample for v1).
 
-## Open items to resolve in the plan (via cross-check)
+## Open items to resolve in the plan
 
-- Exact RESPACK `input.in` trailing-block format/order (k-coords after
-  `&param_interpolation`; whether labels are allowed inline) — verify against the
-  reference `respack-wannier-py` `input_parser.py` / `m_rdinput`.
-- Whether to reuse `Struct2QE._set_pseudo_info` directly (composition) or extract
-  a shared pp loader alongside the `wannier_counts` helper.
+- Whether the shared pp loader is a thin extraction of
+  `Struct2QE._set_pseudo_info` (composition) or a new function in
+  `cif2x/wannier.py` alongside `wannier_counts`; either way, QE behavior must stay
+  unchanged (covered by existing QE tests).

--- a/docs/superpowers/specs/2026-06-30-respack-target-design.md
+++ b/docs/superpowers/specs/2026-06-30-respack-target-design.md
@@ -1,0 +1,159 @@
+# cif2x RESPACK target (`-t respack`) — design
+
+Date: 2026-06-30
+
+## Goal
+
+Add a `respack` target so `cif2x -t respack input.yaml structure.cif` emits the
+whole RESPACK workflow in one run: the Quantum ESPRESSO inputs RESPACK consumes
+(`scf` / `nscf` / `bands`, via the existing QE generator) **and** the RESPACK
+control input `input.in` (a new generator). The structure-derived fields of
+`input.in` are auto-filled (number of Wannier functions, the high-symmetry
+k-path, the interpolation grid); physics parameters come from a template /
+`content`. Initial guesses use **SCDM** (`N_initial_guess = 0`), so no manual
+Gaussian projection block is emitted.
+
+Scope: the QE target stays unchanged; `respack` reuses it for QE-mode tasks.
+
+## Background (verified)
+
+- Targets are dispatched in `main.py` via `normalize_target` + a `Struct2X`
+  class; `input_validator.TARGETS` holds per-target aliases/required/allowed
+  keys. Each `cif2x` run uses ONE target, but iterates a `tasks:` list.
+- `Struct2QE` already computes the Wannier counts: `_find_nbnd_info`
+  (`struct2qe.py:179-204`) sets `self.num_wann`, `self.nexclude`,
+  `self.num_bands` from `pp_file` `orbitals`/`nexclude` (loaded by
+  `_set_pseudo_info`). These are exactly `input.in`'s `N_wannier` and the QE
+  `nbnd` for the nscf step.
+- `cards._generate_band_path` builds a high-symmetry path from pymatgen
+  `HighSymmKpath` (added for `bands`); `input.in`'s `&param_interpolation`
+  block needs the same high-symmetry points (without per-segment divisions).
+- RESPACK `input.in` (reference: `samples/*/input.in` in the user's
+  `respack-wannier-py`) is Fortran namelists + trailing non-namelist blocks:
+  `&param_chiqw` (Ecut_for_eps, flg_cRPA), `&param_wannier` (N_wannier,
+  Lower/Upper_energy_window, N_initial_guess) [+ optional Gaussian initial-guess
+  lines], `&param_interpolation` (dense, N_sym_points) + a high-symmetry k-coords
+  block, `&param_visualization`, `&param_calc_int`. Per the reference parser
+  (`input_parser.py:367-372`), `N_initial_guess = 0` means SCDM-only and the
+  Gaussian block is omitted.
+- `f90nml` is already a dependency; `Struct2QE` parses QE templates via
+  `QEInputGeneral` (qe_tools), which is QE-specific — NOT reused for RESPACK.
+
+## Decisions
+
+- `-t respack` routes **per task by `mode`**: QE modes
+  (`scf`/`nscf`/`bands`/`relax`/`vc-relax`/`dos`) → `Struct2QE`; `mode: respack`
+  → new `Struct2RESPACK`; anything else → `InputValidationError`.
+- `input.in` is built **template + content merge** (like QE): the template holds
+  the `&param_*` namelists (physics); cif2x fills the structure-derived blanks
+  and appends the auto-generated k-path block.
+- **SCDM** initial guess: set `N_initial_guess = 0`, emit no Gaussian block (v1).
+- Wannier-count computation is **factored into a shared helper** so QE and
+  RESPACK produce identical `num_wann`/`nexclude`.
+
+## Components
+
+### 1. Shared Wannier-count helper
+
+Extract the `num_wann`/`nexclude` computation currently inside
+`Struct2QE._find_nbnd_info` into a reusable function (new
+`src/cif2x/wannier.py`, or a function in `cif2x/qe/tools.py`), e.g.
+`wannier_counts(species, pp_list, *, spinor_factor) -> {num_wann, nexclude, num_bands, nbnd}`.
+`Struct2QE._find_nbnd_info` calls it (behavior unchanged — covered by existing
+QE tests); `Struct2RESPACK` calls it for `N_wannier`.
+
+### 2. `Struct2RESPACK` (`src/cif2x/struct2respack.py`)
+
+`__init__(params, struct)` then `write_input(output_file, output_dir, dry_run=False)`,
+matching the other generators (and supporting `--dry-run` via `utils.dryrun_emit`).
+
+Build `input.in`:
+1. Load the RESPACK template (`params["template"]`) namelists with `f90nml`;
+   deep-merge `params["content"]` on top (reuse `deepupdate`).
+2. Resolve pseudopotential / orbital info (reuse `Struct2QE._set_pseudo_info`
+   logic or share it) and compute `num_wann` via the shared helper.
+3. Auto-fill:
+   - `&param_wannier`: `N_wannier = num_wann`; `N_initial_guess = 0` (SCDM);
+     `Lower_energy_window` / `Upper_energy_window` from content (physics).
+   - `&param_interpolation`: `dense` from content (or a k-resolution default);
+     `N_sym_points = <number of high-symmetry points>`.
+   - `&param_chiqw` / `&param_calc_int` / `&param_visualization`: passthrough
+     from template/content.
+4. Render: write the `&param_*` namelists in RESPACK order, and **after
+   `&param_interpolation`'s `/`, append the high-symmetry k-coords block** — one
+   line per point `kx ky kz  ! label`, count = `N_sym_points`, from
+   `HighSymmKpath`. (Cross-check the exact RESPACK `m_rdinput` trailing-block
+   format/order against the reference `respack-wannier-py` `input_parser.py`
+   during implementation.)
+
+### 3. Dispatch + validation
+
+- `main._run`: when `target == "respack"`, select the generator per task:
+  `mode in _QE_MODES → Struct2QE`, `mode == "respack" → Struct2RESPACK`, else
+  `InputValidationError("task N: unknown mode '<m>' for target 'respack'")`.
+  Other targets keep the single-generator loop. Factor the per-task body
+  (params build, optional injection, write_input) so both paths share it.
+- `input_validator.TARGETS["respack"]`: `aliases = ("respack",)`;
+  per-task allowed keys = QE allowed ∪ respack-specific (`template`, `content`,
+  `output_file`, `output_dir`, `mode`, `optional`); required = `mode`,
+  `output_file`. Mode legality (QE-mode vs `respack`) is checked at dispatch.
+
+### 4. QE side (no new code)
+
+The `scf`/`nscf`/`bands` tasks are ordinary `Struct2QE` tasks. For RESPACK the
+nscf task uses `K_POINTS` `crystal` (uniform explicit mesh, already supported)
+and `nbnd` is auto-filled from `num_bands` (already supported). Configuration
+lives in the sample `input.yaml`.
+
+## Error handling
+
+- `respack` task with an unrecognized `mode` → `InputValidationError` (clean exit).
+- Missing `pp_file`/`orbitals` when `num_wann` is needed → the existing
+  `Struct2QE` error path (reused), surfaced clearly.
+- Template parse failure → `InputValidationError` with the file name.
+
+## Testing (network-free where possible)
+
+- **Shared helper:** `wannier_counts` returns the expected `num_wann`/`nexclude`
+  for a small species list + a stub pp table; existing QE `nbnd` tests still pass
+  (behavior unchanged).
+- **Struct2RESPACK:** with a small structure (`use_ibrav=False`), a minimal
+  RESPACK template, and a stub pp table, assert the rendered `input.in` has
+  `N_wannier` = computed num_wann, `N_initial_guess = 0`, no Gaussian block, a
+  `&param_interpolation` k-coords block whose count matches the high-symmetry
+  points, and that template/content physics values pass through. Use
+  `pytest.importorskip("pymatgen")`.
+- **Dispatch:** `-t respack` routes a `mode: scf` task to `Struct2QE` and a
+  `mode: respack` task to `Struct2RESPACK` (monkeypatch both, assert each
+  `write_input` is called for the right task); an unknown mode raises.
+- **Validation:** respack target accepts the sample tasks; an unknown top-level
+  or task key is rejected.
+
+## Documentation + sample
+
+- Command reference (en/ja): add `respack` to the targets list.
+- A new section / tutorial example showing the full chain `input.yaml`
+  (`tasks:` = scf, nscf, bands QE tasks + a `mode: respack` task) plus a RESPACK
+  `input.in` template, and noting SCDM (`N_initial_guess = 0`) and that energy
+  windows / Ecut / flg_cRPA are user physics.
+- A `sample/cif2x/respack/<case>/` directory mirroring the existing samples
+  (structure file + input.yaml + RESPACK template), if a runnable example is
+  wanted (decide in the plan; may be docs-only inline like the sweep examples).
+
+## Out of scope (v1)
+
+- Manual Gaussian initial-guess projections (SCDM only).
+- Spin-polarized split `input.in.up` / `input.in.dn` (LSDA) — note as a
+  follow-up.
+- `qe2respack` invocation (a runtime conversion step the user runs; cif2x only
+  emits inputs).
+- Auto-deriving energy windows / cRPA parameters (physics; template/content).
+- Cross-tool orchestration beyond per-task routing within one `-t respack` run.
+
+## Open items to resolve in the plan (via cross-check)
+
+- Exact RESPACK `input.in` trailing-block format/order (k-coords after
+  `&param_interpolation`; whether labels are allowed inline) — verify against the
+  reference `respack-wannier-py` `input_parser.py` / `m_rdinput`.
+- Whether to reuse `Struct2QE._set_pseudo_info` directly (composition) or extract
+  a shared pp loader alongside the `wannier_counts` helper.

--- a/sample/cif2x/respack/SrVO3/README.md
+++ b/sample/cif2x/respack/SrVO3/README.md
@@ -1,0 +1,7 @@
+# SrVO3 RESPACK sample
+
+`cif2x -t respack input.yaml SrVO3.cif` emits `scf.in`, `nscf.in`, and `input.in`.
+Provide `SrVO3.cif`, `pp.csv`, and the pseudopotentials under `./pseudo`.
+`N_wannier = 3` (t2g) and the energy windows are physics choices in
+`respack.in_tmpl`. Run order: scf → nscf → `qe2respack` → `respack` (the
+`respack-wannier-py` port; SCDM, `N_initial_guess = 0`).

--- a/sample/cif2x/respack/SrVO3/input.yaml
+++ b/sample/cif2x/respack/SrVO3/input.yaml
@@ -1,0 +1,23 @@
+structure:
+  use_primitive: true
+  use_ibrav: false
+
+optional:
+  pseudo_dir: ./pseudo
+  pp_file: pp.csv
+
+tasks:
+  - mode: scf
+    output_file: scf.in
+    content:
+      control: { calculation: scf }
+      K_POINTS: { option: automatic, grid: [6, 6, 6] }
+  - mode: nscf
+    output_file: nscf.in
+    content:
+      control: { calculation: nscf }
+      system: { nosym: true, noinv: true }
+      K_POINTS: { option: crystal, grid: [6, 6, 6] }
+  - mode: respack
+    output_file: input.in
+    template: respack.in_tmpl

--- a/sample/cif2x/respack/SrVO3/respack.in_tmpl
+++ b/sample/cif2x/respack/SrVO3/respack.in_tmpl
@@ -1,0 +1,14 @@
+&param_chiqw
+Ecut_for_eps = 5.0
+flg_cRPA = 1
+/
+&param_wannier
+N_wannier = 3
+Lower_energy_window = 11.0
+Upper_energy_window = 14.2
+/
+&param_interpolation
+dense = 8, 8, 8
+/
+&param_calc_int
+/

--- a/src/cif2x/input_validator.py
+++ b/src/cif2x/input_validator.py
@@ -40,6 +40,11 @@ TARGETS = {
         "required": ("output_file",),
         "allowed": _COMMON_ALLOWED | {"mode", "workdir"},
     },
+    "respack": {
+        "aliases": ("respack",),
+        "required": ("mode", "output_file"),
+        "allowed": _COMMON_ALLOWED | {"mode"},
+    },
 }
 
 _TOP_LEVEL_KEYS = {"structure", "optional", "tasks"}

--- a/src/cif2x/main.py
+++ b/src/cif2x/main.py
@@ -142,6 +142,12 @@ def _run(args):
         output_file = info.get("output_file")
         output_dir = info.get("output_dir", ".")
 
+        if target == "respack" and info.get("mode") == "nscf":
+            _sys = (info.get("content") or {}).get("system") or {}
+            if not _sys.get("nosym") or not _sys.get("noinv"):
+                logger.warning(
+                    "respack: the nscf task should set content.system.nosym: true "
+                    "and noinv: true (required by qe2respack).")
         gen_cls = _respack_generator(info.get("mode"), idx) if target == "respack" else generator_cls
         generator = gen_cls(params, struct)
         generator.write_input(output_file, output_dir, dry_run=args.dry_run)

--- a/src/cif2x/main.py
+++ b/src/cif2x/main.py
@@ -14,6 +14,7 @@ from cif2x.struct2qe import Struct2QE
 from cif2x.struct2vasp import Struct2Vasp
 from cif2x.struct2openmx import Struct2OpenMX
 from cif2x.struct2akaikkr import Struct2AkaiKKR
+from cif2x.struct2respack import Struct2RESPACK
 from cif2x.input_validator import (
     InputValidationError,
     normalize_target,
@@ -74,6 +75,17 @@ def _generator_class(target):
     }[target]
 
 
+def _respack_generator(mode, taskid):
+    """Pick the generator for a task under -t respack, by mode."""
+    if mode in ("scf", "nscf", "bands"):
+        return Struct2QE
+    if mode == "respack":
+        return Struct2RESPACK
+    raise InputValidationError(
+        f"task {taskid}: unsupported mode '{mode}' for target 'respack' "
+        "(use scf, nscf, bands, or respack).")
+
+
 def _run(args):
     target = normalize_target(args.target)
     _require_one_source(args)
@@ -108,7 +120,13 @@ def _run(args):
     # `optional:` written with no entries parses to None; treat it as empty so
     # generators that read optional.get(...) do not crash on None.
     info_optional = info_dict.get("optional") or {}
-    generator_cls = _generator_class(target)
+    generator_cls = None if target == "respack" else _generator_class(target)
+
+    if target == "respack":
+        if not struct_params.get("use_primitive") or struct_params.get("use_ibrav"):
+            raise InputValidationError(
+                "target 'respack' requires structure.use_primitive: true and "
+                "use_ibrav: false (the high-symmetry k-path needs the primitive cell).")
 
     for idx, info in enumerate(info_dict["tasks"], start=1):
         logger.info(f"start task {idx}")
@@ -122,7 +140,8 @@ def _run(args):
         output_file = info.get("output_file")
         output_dir = info.get("output_dir", ".")
 
-        generator = generator_cls(params, struct)
+        gen_cls = _respack_generator(info.get("mode"), idx) if target == "respack" else generator_cls
+        generator = gen_cls(params, struct)
         generator.write_input(output_file, output_dir, dry_run=args.dry_run)
 
 

--- a/src/cif2x/main.py
+++ b/src/cif2x/main.py
@@ -19,6 +19,7 @@ from cif2x.input_validator import (
     InputValidationError,
     normalize_target,
     validate_input,
+    _target_choices,
 )
 from cif2x.mp_source import fetch_to_cif
 
@@ -39,7 +40,8 @@ def main():
     parser.add_argument("--version", action="version", version="%(prog)s version {}".format(__version__))
     parser.add_argument("-v", "--verbose", action="count", default=0, help="increase output verbosity")
     parser.add_argument("-q", "--quiet", action="count", default=0, help="increase output verbosity")
-    parser.add_argument("-t", "--target", action="store", required=True, help="target application. Supported targets: quantum_espresso (qe, espresso), vasp, openmx, akaikkr. (case-insensitive)")
+    parser.add_argument("-t", "--target", action="store", required=True,
+                        help="target application. Supported targets: {}. (case-insensitive)".format(_target_choices()))
     parser.add_argument("--dry-run", action="store_true", default=False, help="print the generated input files to stdout instead of writing them")
 
     args = parser.parse_args()

--- a/src/cif2x/struct2respack.py
+++ b/src/cif2x/struct2respack.py
@@ -159,7 +159,7 @@ class Struct2RESPACK:
 
         interp = data.setdefault("param_interpolation", {})
         rsf = interp.get("reading_sk_format", 0)
-        if isinstance(rsf, bool):
+        if isinstance(rsf, bool) or (isinstance(rsf, float) and not rsf.is_integer()):
             raise InputValidationError(
                 "respack: 'reading_sk_format' must be an integer (got {!r}).".format(rsf))
         try:

--- a/src/cif2x/struct2respack.py
+++ b/src/cif2x/struct2respack.py
@@ -34,6 +34,9 @@ def _deepupdate(dst, src):
 
 def _has_content_outside_namelists(text):
     """True if a non-blank, non-comment line sits outside a &name.../ block."""
+    # NOTE: assumes namelist value lines do not end in a bare '/' (true for
+    # RESPACK's numeric/quoted namelists); an unquoted token ending in '/'
+    # would falsely close the block. Fails safe (rejects) rather than mis-render.
     inside = False
     for raw in text.splitlines():
         line = raw.split("!", 1)[0].strip()
@@ -114,13 +117,25 @@ class Struct2RESPACK:
 
         data = {k: dict(v) for k, v in nml.items()}
         content = self.params.get("content") or {}
-        norm = {str(k).lower(): {str(kk).lower(): vv for kk, vv in (v or {}).items()}
-                for k, v in content.items()}
+        norm = {}
+        for k, v in content.items():
+            name = str(k).lower()
+            if name not in _ALLOWED_NAMELISTS:
+                raise InputValidationError(
+                    "respack content: unexpected namelist '{}'. Only RESPACK "
+                    "&param_* namelists are allowed.".format(name))
+            if v is None:
+                norm[name] = {}
+            elif isinstance(v, dict):
+                norm[name] = {str(kk).lower(): vv for kk, vv in v.items()}
+            else:
+                raise InputValidationError(
+                    "respack content: '{}' must be a mapping of namelist keys.".format(k))
         _deepupdate(data, norm)
 
         wann = data.setdefault("param_wannier", {})
         n_wannier = wann.get("n_wannier")
-        if not isinstance(n_wannier, int) or n_wannier <= 0:
+        if not isinstance(n_wannier, int) or isinstance(n_wannier, bool) or n_wannier <= 0:
             raise InputValidationError(
                 "respack: &param_wannier 'N_wannier' must be a positive integer "
                 f"(got {n_wannier!r}); it is user physics and is not auto-derived.")

--- a/src/cif2x/struct2respack.py
+++ b/src/cif2x/struct2respack.py
@@ -32,23 +32,46 @@ def _deepupdate(dst, src):
             dst[k] = v
 
 
+def _first_unquoted_slash(text):
+    """Index of the first '/' not inside a single/double-quoted string, else -1.
+
+    Fortran namelists terminate at the first unquoted '/'; a '/' inside a quoted
+    value (e.g. a file path) does not close the block.
+    """
+    quote = None
+    for i, ch in enumerate(text):
+        if quote is not None:
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch == "/":
+            return i
+    return -1
+
+
 def _has_content_outside_namelists(text):
-    """True if a non-blank, non-comment line sits outside a &name.../ block."""
-    # NOTE: assumes namelist value lines do not end in a bare '/' (true for
-    # RESPACK's numeric/quoted namelists); an unquoted token ending in '/'
-    # would falsely close the block. Fails safe (rejects) rather than mis-render.
+    """True if a non-blank, non-comment line sits outside a &name.../ block.
+
+    A namelist terminates at the first unquoted '/'; any non-blank text after
+    that terminator (whether on the &open line or a dedicated close line) is
+    content outside the namelist and is rejected. Quoted '/' (e.g. paths) does
+    not close the block. An unquoted token containing '/' still fails safe
+    (rejects) rather than mis-render.
+    """
     inside = False
     for raw in text.splitlines():
         line = raw.split("!", 1)[0].strip()
         if not line:
             continue
-        if inside:
-            if line == "/" or line.endswith("/"):
-                inside = False
-        else:
-            if line.startswith("&"):
-                inside = not (line.endswith("/") or "/" in line[1:])
-            else:
+        if not inside:
+            if not line.startswith("&"):
+                return True
+            inside = True
+        slash = _first_unquoted_slash(line)
+        if slash != -1:
+            inside = False
+            if line[slash + 1:].strip():
                 return True
     return False
 

--- a/src/cif2x/struct2respack.py
+++ b/src/cif2x/struct2respack.py
@@ -75,14 +75,16 @@ def _kpath(structure):
 
 
 def _as_three_ints(value, *, key):
+    if isinstance(value, bool):
+        raise InputValidationError(
+            "respack: '{}' must be three integers (got {!r}).".format(key, value))
     if isinstance(value, int):
         return [value, value, value]
-    if isinstance(value, (list, tuple)) and len(value) == 3 and all(
-        isinstance(v, int) for v in value
-    ):
+    if (isinstance(value, (list, tuple)) and len(value) == 3
+            and all(isinstance(v, int) and not isinstance(v, bool) for v in value)):
         return list(value)
     raise InputValidationError(
-        f"respack: '{key}' must be three integers (got {value!r}).")
+        "respack: '{}' must be three integers (got {!r}).".format(key, value))
 
 
 class Struct2RESPACK:
@@ -146,7 +148,8 @@ class Struct2RESPACK:
         wann["n_initial_guess"] = 0
         lo = wann.get("lower_energy_window")
         hi = wann.get("upper_energy_window")
-        if not isinstance(lo, (int, float)) or not isinstance(hi, (int, float)):
+        if (not isinstance(lo, (int, float)) or isinstance(lo, bool)
+                or not isinstance(hi, (int, float)) or isinstance(hi, bool)):
             raise InputValidationError(
                 "respack: 'Lower_energy_window' and 'Upper_energy_window' are "
                 "required numeric values in &param_wannier.")
@@ -155,7 +158,14 @@ class Struct2RESPACK:
                 f"respack: energy window must have lower < upper (got {lo} >= {hi}).")
 
         interp = data.setdefault("param_interpolation", {})
-        if int(interp.get("reading_sk_format", 0)) != 0:
+        rsf = interp.get("reading_sk_format", 0)
+        try:
+            rsf = int(rsf)
+        except (TypeError, ValueError):
+            raise InputValidationError(
+                "respack: 'reading_sk_format' must be an integer (got {!r}).".format(
+                    interp.get("reading_sk_format")))
+        if rsf != 0:
             raise InputValidationError(
                 "respack: only reading_sk_format = 0 is supported.")
         interp["dense"] = _as_three_ints(interp.get("dense"), key="dense")

--- a/src/cif2x/struct2respack.py
+++ b/src/cif2x/struct2respack.py
@@ -159,6 +159,9 @@ class Struct2RESPACK:
 
         interp = data.setdefault("param_interpolation", {})
         rsf = interp.get("reading_sk_format", 0)
+        if isinstance(rsf, bool):
+            raise InputValidationError(
+                "respack: 'reading_sk_format' must be an integer (got {!r}).".format(rsf))
         try:
             rsf = int(rsf)
         except (TypeError, ValueError):

--- a/src/cif2x/struct2respack.py
+++ b/src/cif2x/struct2respack.py
@@ -1,0 +1,172 @@
+"""Generate a RESPACK ``input.in`` control file from a namelist-only template.
+
+``N_wannier`` and the physics (energy windows, dense, cRPA params) come from the
+template/``content``; cif2x only auto-generates the ``&param_interpolation``
+high-symmetry k-path (from pymatgen) and forces SCDM (``N_initial_guess = 0``).
+"""
+
+import io
+import logging
+import warnings
+from pathlib import Path
+
+import f90nml
+
+from cif2x.input_validator import InputValidationError
+from cif2x.utils import dryrun_emit
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_NAMELISTS = (
+    "param_chiqw", "param_wannier", "param_interpolation",
+    "param_visualization", "param_calc_int",
+)
+_NAMELIST_ORDER = _ALLOWED_NAMELISTS
+
+
+def _deepupdate(dst, src):
+    for k, v in src.items():
+        if isinstance(v, dict) and isinstance(dst.get(k), dict):
+            _deepupdate(dst[k], v)
+        else:
+            dst[k] = v
+
+
+def _has_content_outside_namelists(text):
+    """True if a non-blank, non-comment line sits outside a &name.../ block."""
+    inside = False
+    for raw in text.splitlines():
+        line = raw.split("!", 1)[0].strip()
+        if not line:
+            continue
+        if inside:
+            if line == "/" or line.endswith("/"):
+                inside = False
+        else:
+            if line.startswith("&"):
+                inside = not (line.endswith("/") or "/" in line[1:])
+            else:
+                return True
+    return False
+
+
+def _kpath(structure):
+    """Return (n_sym_points list, [(label, (kx,ky,kz)), ...]) from HighSymmKpath."""
+    from pymatgen.symmetry.bandstructure import HighSymmKpath
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        kpath = HighSymmKpath(structure).kpath
+    for w in caught:
+        if not issubclass(w.category, DeprecationWarning):
+            logger.warning("band path: %s", w.message)
+    coords = kpath["kpoints"]
+    segments = kpath["path"]
+    n_sym_points = [len(seg) for seg in segments]
+    rows = []
+    for seg in segments:
+        for label in seg:
+            c = coords[label]
+            rows.append((label, (float(c[0]), float(c[1]), float(c[2]))))
+    return n_sym_points, rows
+
+
+def _as_three_ints(value, *, key):
+    if isinstance(value, int):
+        return [value, value, value]
+    if isinstance(value, (list, tuple)) and len(value) == 3 and all(
+        isinstance(v, int) for v in value
+    ):
+        return list(value)
+    raise InputValidationError(
+        f"respack: '{key}' must be three integers (got {value!r}).")
+
+
+class Struct2RESPACK:
+    def __init__(self, params, struct):
+        self.params = params
+        self.struct = struct
+        self._data, self._n_sym_points, self._kpath_rows = self._build()
+
+    def _build(self):
+        template = self.params.get("template")
+        if not template:
+            raise InputValidationError("respack task: 'template' is required.")
+        path = Path(template)
+        if not path.exists():
+            raise InputValidationError(f"respack template not found: {template}")
+        text = path.read_text()
+        try:
+            nml = f90nml.reads(text)
+        except Exception as e:
+            raise InputValidationError(
+                f"failed to parse RESPACK template '{template}': {e}")
+        for name in nml:
+            if name not in _ALLOWED_NAMELISTS:
+                raise InputValidationError(
+                    f"respack template: unexpected namelist '&{name}'. Only RESPACK "
+                    f"&param_* namelists are allowed (namelist-only templates).")
+        if _has_content_outside_namelists(text):
+            raise InputValidationError(
+                "respack template: content outside &param_* namelists is not "
+                "allowed (templates are namelist-only; cif2x generates the "
+                "k-coords block).")
+
+        data = {k: dict(v) for k, v in nml.items()}
+        content = self.params.get("content") or {}
+        norm = {str(k).lower(): {str(kk).lower(): vv for kk, vv in (v or {}).items()}
+                for k, v in content.items()}
+        _deepupdate(data, norm)
+
+        wann = data.setdefault("param_wannier", {})
+        n_wannier = wann.get("n_wannier")
+        if not isinstance(n_wannier, int) or n_wannier <= 0:
+            raise InputValidationError(
+                "respack: &param_wannier 'N_wannier' must be a positive integer "
+                f"(got {n_wannier!r}); it is user physics and is not auto-derived.")
+        if wann.get("n_initial_guess", 0) not in (0, None):
+            raise InputValidationError(
+                "respack: v1 is SCDM-only — 'N_initial_guess' must be 0 (got "
+                f"{wann.get('n_initial_guess')!r}).")
+        wann["n_initial_guess"] = 0
+        lo = wann.get("lower_energy_window")
+        hi = wann.get("upper_energy_window")
+        if not isinstance(lo, (int, float)) or not isinstance(hi, (int, float)):
+            raise InputValidationError(
+                "respack: 'Lower_energy_window' and 'Upper_energy_window' are "
+                "required numeric values in &param_wannier.")
+        if lo >= hi:
+            raise InputValidationError(
+                f"respack: energy window must have lower < upper (got {lo} >= {hi}).")
+
+        interp = data.setdefault("param_interpolation", {})
+        if int(interp.get("reading_sk_format", 0)) != 0:
+            raise InputValidationError(
+                "respack: only reading_sk_format = 0 is supported.")
+        interp["dense"] = _as_three_ints(interp.get("dense"), key="dense")
+
+        n_sym_points, rows = _kpath(self.struct.structure)
+        interp["n_sym_points"] = n_sym_points
+        return data, n_sym_points, rows
+
+    def render(self):
+        out = []
+        for name in _NAMELIST_ORDER:
+            if name not in self._data:
+                continue
+            buf = io.StringIO()
+            f90nml.Namelist({name: self._data[name]}).write(buf)
+            out.append(buf.getvalue())
+            if name == "param_interpolation":
+                for label, (x, y, z) in self._kpath_rows:
+                    out.append("{:.6f} {:.6f} {:.6f}  ! {}\n".format(x, y, z, label))
+        return "".join(out)
+
+    def write_input(self, output_file, output_dir, dry_run=False):
+        content = self.render()
+        if dry_run:
+            dryrun_emit(str(Path(output_dir, output_file)), content)
+            return
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        with open(Path(output_dir, output_file), "w") as fp:
+            fp.write(content)

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -243,3 +243,70 @@ def test_mp_id_path_reaches_writer(monkeypatch, tmp_path):
     assert captured["struct_cif"] == captured["dest"]
     assert captured["struct_cif_exists"] is True
     assert captured["struct_params"] == {}
+
+
+def test_respack_routes_qe_and_respack_tasks(monkeypatch, tmp_path):
+    pytest.importorskip("pymatgen")
+    captured = {"qe": [], "respack": []}
+
+    class _QE:
+        def __init__(self, params, struct):
+            pass
+
+        def write_input(self, *a, **k):
+            captured["qe"].append(True)
+
+    class _RP:
+        def __init__(self, params, struct):
+            pass
+
+        def write_input(self, *a, **k):
+            captured["respack"].append(True)
+
+    monkeypatch.setattr(main_mod, "Cif2Struct", lambda *a, **k: object())
+    monkeypatch.setattr(main_mod, "Struct2QE", _QE)
+    monkeypatch.setattr(main_mod, "Struct2RESPACK", _RP)
+    yf = tmp_path / "input.yaml"
+    yf.write_text(
+        "structure:\n  use_primitive: true\n"
+        "tasks:\n"
+        "  - mode: scf\n    output_file: scf.in\n"
+        "  - mode: respack\n    output_file: input.in\n    template: r.in_tmpl\n"
+    )
+    cif = tmp_path / "x.cif"
+    cif.write_text("")
+    monkeypatch.setattr(sys, "argv", ["cif2x", "-t", "respack", str(yf), str(cif)])
+    main_mod.main()
+    assert captured["qe"] == [True]
+    assert captured["respack"] == [True]
+
+
+def test_respack_rejects_non_workflow_mode(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(main_mod, "Cif2Struct", lambda *a, **k: object())
+    yf = tmp_path / "input.yaml"
+    yf.write_text(
+        "structure:\n  use_primitive: true\n"
+        "tasks:\n  - mode: relax\n    output_file: x.in\n"
+    )
+    cif = tmp_path / "x.cif"
+    cif.write_text("")
+    monkeypatch.setattr(sys, "argv", ["cif2x", "-t", "respack", str(yf), str(cif)])
+    with caplog.at_level("ERROR"):
+        with pytest.raises(SystemExit):
+            main_mod.main()
+    assert "relax" in caplog.text
+
+
+def test_respack_requires_primitive_cell(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(main_mod, "Cif2Struct", lambda *a, **k: object())
+    yf = tmp_path / "input.yaml"
+    yf.write_text(
+        "tasks:\n  - mode: respack\n    output_file: input.in\n    template: r\n"
+    )
+    cif = tmp_path / "x.cif"
+    cif.write_text("")
+    monkeypatch.setattr(sys, "argv", ["cif2x", "-t", "respack", str(yf), str(cif)])
+    with caplog.at_level("ERROR"):
+        with pytest.raises(SystemExit):
+            main_mod.main()
+    assert "use_primitive" in caplog.text

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -310,3 +310,29 @@ def test_respack_requires_primitive_cell(monkeypatch, tmp_path, caplog):
         with pytest.raises(SystemExit):
             main_mod.main()
     assert "use_primitive" in caplog.text
+
+
+def test_respack_nscf_warns_without_nosym(monkeypatch, tmp_path, caplog):
+    pytest.importorskip("pymatgen")
+
+    class _Dummy:
+        def __init__(self, *a, **k):
+            pass
+
+        def write_input(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(main_mod, "Cif2Struct", lambda *a, **k: object())
+    monkeypatch.setattr(main_mod, "Struct2QE", _Dummy)
+    monkeypatch.setattr(main_mod, "Struct2RESPACK", _Dummy)
+    yf = tmp_path / "input.yaml"
+    yf.write_text(
+        "structure:\n  use_primitive: true\n"
+        "tasks:\n  - mode: nscf\n    output_file: nscf.in\n"
+    )
+    cif = tmp_path / "x.cif"
+    cif.write_text("")
+    monkeypatch.setattr(sys, "argv", ["cif2x", "-t", "respack", str(yf), str(cif)])
+    with caplog.at_level("WARNING"):
+        main_mod.main()
+    assert "nosym" in caplog.text

--- a/tests/test_respack.py
+++ b/tests/test_respack.py
@@ -124,6 +124,35 @@ def test_reading_sk_format_nonzero_rejected(tmp_path):
         _render(tmp_path, template=_write(tmp_path, t))
 
 
+def test_template_not_found_rejected(tmp_path):
+    with pytest.raises(InputValidationError, match="not found"):
+        Struct2RESPACK({"template": str(tmp_path / "nope.in_tmpl"), "content": {}},
+                       _Struct(_cubic()))
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_n_wannier_nonpositive_rejected(tmp_path, bad):
+    t = _TEMPLATE.replace("N_wannier = 3", "N_wannier = {}".format(bad))
+    with pytest.raises(InputValidationError, match="N_wannier"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_missing_windows_rejected(tmp_path):
+    t = (_TEMPLATE
+         .replace("Lower_energy_window = 11.0\n", "")
+         .replace("Upper_energy_window = 14.2\n", ""))
+    with pytest.raises(InputValidationError, match="window|Lower|Upper"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_template_unparseable_rejected(tmp_path):
+    # Unterminated namelist (no closing '/') makes f90nml.reads raise; the
+    # generator must wrap it as a user-facing InputValidationError.
+    t = "&param_wannier\nN_wannier = 3\n"
+    with pytest.raises(InputValidationError, match="parse|failed"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
 def test_write_input_dry_run(tmp_path, capsys):
     params = {"template": _write(tmp_path), "content": {}}
     gen = Struct2RESPACK(params, _Struct(_cubic()))

--- a/tests/test_respack.py
+++ b/tests/test_respack.py
@@ -163,6 +163,24 @@ def test_content_non_mapping_namelist_rejected(tmp_path):
         _render(tmp_path, content={"param_wannier": "oops"})
 
 
+def test_bool_window_rejected(tmp_path):
+    t = _TEMPLATE.replace("Lower_energy_window = 11.0", "Lower_energy_window = .false.")
+    with pytest.raises(InputValidationError, match="window|Lower"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_bool_dense_rejected(tmp_path):
+    t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = .true.")
+    with pytest.raises(InputValidationError, match="dense"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_non_integer_reading_sk_format_rejected(tmp_path):
+    t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8, 8\nreading_sk_format = 'x'")
+    with pytest.raises(InputValidationError, match="reading_sk_format"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
 def test_write_input_dry_run(tmp_path, capsys):
     params = {"template": _write(tmp_path), "content": {}}
     gen = Struct2RESPACK(params, _Struct(_cubic()))

--- a/tests/test_respack.py
+++ b/tests/test_respack.py
@@ -196,3 +196,9 @@ def test_bool_reading_sk_format_rejected(tmp_path):
     t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8, 8\nreading_sk_format = .true.")
     with pytest.raises(InputValidationError, match="reading_sk_format"):
         _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_nonintegral_reading_sk_format_rejected(tmp_path):
+    t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8, 8\nreading_sk_format = 0.5")
+    with pytest.raises(InputValidationError, match="reading_sk_format"):
+        _render(tmp_path, template=_write(tmp_path, t))

--- a/tests/test_respack.py
+++ b/tests/test_respack.py
@@ -1,0 +1,135 @@
+import io
+
+import pytest
+
+pytest.importorskip("pymatgen")
+pytest.importorskip("f90nml")
+
+import f90nml
+from pymatgen.core import Lattice, Structure
+
+from cif2x.input_validator import InputValidationError
+from cif2x.struct2respack import Struct2RESPACK
+
+
+class _Struct:
+    def __init__(self, structure):
+        self.structure = structure
+
+
+def _cubic():
+    return Structure(Lattice.cubic(3.8), ["Cu"], [[0, 0, 0]])
+
+
+_TEMPLATE = """&param_chiqw
+Ecut_for_eps = 5.0
+flg_cRPA = 1
+/
+&param_wannier
+N_wannier = 3
+Lower_energy_window = 11.0
+Upper_energy_window = 14.2
+/
+&param_interpolation
+dense = 8, 8, 8
+/
+&param_calc_int
+/
+"""
+
+
+def _write(tmp_path, text=_TEMPLATE):
+    p = tmp_path / "respack.in_tmpl"
+    p.write_text(text)
+    return str(p)
+
+
+def _render(tmp_path, structure=None, content=None, template=None):
+    params = {"template": template or _write(tmp_path), "content": content or {}}
+    gen = Struct2RESPACK(params, _Struct(structure or _cubic()))
+    return gen.render()
+
+
+def test_render_passes_through_n_wannier_and_windows(tmp_path):
+    out = _render(tmp_path)
+    nml = f90nml.reads(out)
+    assert nml["param_wannier"]["n_wannier"] == 3
+    assert nml["param_wannier"]["lower_energy_window"] == 11.0
+    assert nml["param_wannier"]["upper_energy_window"] == 14.2
+
+
+def test_render_forces_scdm(tmp_path):
+    out = _render(tmp_path)
+    nml = f90nml.reads(out)
+    assert nml["param_wannier"]["n_initial_guess"] == 0
+    assert "dxy" not in out
+
+
+def test_render_kpath_matches_highsymmkpath_segments(tmp_path):
+    from pymatgen.symmetry.bandstructure import HighSymmKpath
+    s = _cubic()
+    out = _render(tmp_path, structure=s)
+    nml = f90nml.reads(out)
+    kpath = HighSymmKpath(s).kpath
+    seg_lengths = [len(seg) for seg in kpath["path"]]
+    nsp = nml["param_interpolation"]["n_sym_points"]
+    nsp = [nsp] if isinstance(nsp, int) else list(nsp)
+    assert nsp == seg_lengths
+    after = out.split("&param_interpolation", 1)[1]
+    coord_lines = [ln for ln in after.splitlines()
+                   if ln.strip() and not ln.strip().startswith(("/", "&"))
+                   and "=" not in ln]
+    assert len(coord_lines) == sum(seg_lengths)
+
+
+def test_missing_n_wannier_rejected(tmp_path):
+    t = _TEMPLATE.replace("N_wannier = 3\n", "")
+    with pytest.raises(InputValidationError, match="N_wannier"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_nonzero_n_initial_guess_rejected(tmp_path):
+    t = _TEMPLATE.replace("N_wannier = 3", "N_wannier = 3\nN_initial_guess = 3")
+    with pytest.raises(InputValidationError, match="N_initial_guess"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_window_order_rejected(tmp_path):
+    t = _TEMPLATE.replace("Upper_energy_window = 14.2", "Upper_energy_window = 9.0")
+    with pytest.raises(InputValidationError, match="window"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_non_param_namelist_rejected(tmp_path):
+    t = _TEMPLATE + "&system\nnoncolin = .true.\n/\n"
+    with pytest.raises(InputValidationError, match="namelist"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_trailing_content_rejected(tmp_path):
+    t = _TEMPLATE + "garbage line not in a namelist\n"
+    with pytest.raises(InputValidationError, match="namelist-only|outside"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_bad_dense_rejected(tmp_path):
+    t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8")
+    with pytest.raises(InputValidationError, match="dense"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_reading_sk_format_nonzero_rejected(tmp_path):
+    t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8, 8\nreading_sk_format = 1")
+    with pytest.raises(InputValidationError, match="reading_sk_format"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_write_input_dry_run(tmp_path, capsys):
+    params = {"template": _write(tmp_path), "content": {}}
+    gen = Struct2RESPACK(params, _Struct(_cubic()))
+    gen.write_input("input.in", str(tmp_path), dry_run=True)
+    out = capsys.readouterr().out
+    assert "input.in" in out and "&param_wannier" in out
+    assert not (tmp_path / "input.in").exists()
+    gen.write_input("input.in", str(tmp_path), dry_run=False)
+    assert (tmp_path / "input.in").exists()

--- a/tests/test_respack.py
+++ b/tests/test_respack.py
@@ -190,3 +190,9 @@ def test_write_input_dry_run(tmp_path, capsys):
     assert not (tmp_path / "input.in").exists()
     gen.write_input("input.in", str(tmp_path), dry_run=False)
     assert (tmp_path / "input.in").exists()
+
+
+def test_bool_reading_sk_format_rejected(tmp_path):
+    t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8, 8\nreading_sk_format = .true.")
+    with pytest.raises(InputValidationError, match="reading_sk_format"):
+        _render(tmp_path, template=_write(tmp_path, t))

--- a/tests/test_respack.py
+++ b/tests/test_respack.py
@@ -153,6 +153,16 @@ def test_template_unparseable_rejected(tmp_path):
         _render(tmp_path, template=_write(tmp_path, t))
 
 
+def test_content_unknown_namelist_rejected(tmp_path):
+    with pytest.raises(InputValidationError, match="unexpected namelist"):
+        _render(tmp_path, content={"param_bogus": {"x": 1}})
+
+
+def test_content_non_mapping_namelist_rejected(tmp_path):
+    with pytest.raises(InputValidationError, match="mapping"):
+        _render(tmp_path, content={"param_wannier": "oops"})
+
+
 def test_write_input_dry_run(tmp_path, capsys):
     params = {"template": _write(tmp_path), "content": {}}
     gen = Struct2RESPACK(params, _Struct(_cubic()))

--- a/tests/test_respack.py
+++ b/tests/test_respack.py
@@ -112,6 +112,34 @@ def test_trailing_content_rejected(tmp_path):
         _render(tmp_path, template=_write(tmp_path, t))
 
 
+def test_trailing_content_after_close_line_rejected(tmp_path):
+    # Non-blank text after the terminating '/' on the close line is outside
+    # the namelist; f90nml silently drops it, so the validator must reject it.
+    t = _TEMPLATE.rstrip("\n") + "  trailing junk\n"
+    with pytest.raises(InputValidationError, match="namelist-only|outside"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_trailing_content_after_inline_close_rejected(tmp_path):
+    # Same-line '&name ... / junk': the '/' terminates the namelist and the
+    # trailing 'junk' is outside content that must be rejected, not dropped.
+    t = ("&param_wannier N_wannier=3 Lower_energy_window=11.0 "
+         "Upper_energy_window=14.2 / junk\n"
+         "&param_interpolation\ndense = 8, 8, 8\n/\n")
+    with pytest.raises(InputValidationError, match="namelist-only|outside"):
+        _render(tmp_path, template=_write(tmp_path, t))
+
+
+def test_quoted_slash_value_not_rejected(tmp_path):
+    # A '/' inside a quoted value (e.g. a path) must NOT be treated as the
+    # namelist terminator — this template is valid and must render.
+    t = _TEMPLATE.replace(
+        "&param_calc_int\n/\n",
+        "&param_calc_int\nfile_name = './dir/out.dat'\n/\n")
+    out = _render(tmp_path, template=_write(tmp_path, t))
+    assert "&param_wannier" in out
+
+
 def test_bad_dense_rejected(tmp_path):
     t = _TEMPLATE.replace("dense = 8, 8, 8", "dense = 8, 8")
     with pytest.raises(InputValidationError, match="dense"):


### PR DESCRIPTION
## Summary

- Add a new `-t respack` target that generates a complete RESPACK (cRPA/Wannier) workflow from a CIF + YAML: the Quantum ESPRESSO `scf`/`nscf` inputs (plus an optional `bands` task) and the RESPACK control file `input.in`.
- Per-task `mode` routing: `scf`/`nscf`/`bands` reuse the existing QE generator; `mode: respack` is handled by the new `Struct2RESPACK` generator.
- `Struct2RESPACK` fills only the `&param_interpolation` high-symmetry k-path (from pymatgen) and forces SCDM initial guesses (`N_initial_guess = 0`). `N_wannier` and the energy windows are user physics supplied via the template/`content` and are validated, not auto-derived.
- Enforces a standardized primitive cell (`structure.use_primitive: true`, `use_ibrav: false`) so the written k-path stays consistent with the QE cell; warns when an `nscf` task omits `nosym`/`noinv` (required by `qe2respack`).
- Templates are namelist-only and restricted to RESPACK `&param_*` namelists; clear validation errors on unparseable templates, unexpected namelists, content outside namelists, bad `N_wannier`/windows/`dense`/`reading_sk_format`, etc.
- Docs (EN/JA command reference) and a runnable SrVO3 sample (3-task scf/nscf/respack workflow, t2g `N_wannier = 3`).

## Test Plan

- [x] `pytest -q` — 232 passed (23 new tests in `tests/test_respack.py` plus CLI routing tests in `tests/test_main_cli.py`)
- [x] Verified RESPACK `input.in` format (multi-segment `N_sym_points`, format-0 fractional k-coords) against the reference `respack-wannier-py` parser
- [ ] Run the SrVO3 sample end-to-end against a real RESPACK build

🤖 Generated with [Claude Code](https://claude.com/claude-code)