### PR TITLE
fix(qe): reject unresolved cutoffs and close silent under-convergence paths

### DIFF
--- a/docs/superpowers/plans/2026-07-01-qe-cutoff-required.md
+++ b/docs/superpowers/plans/2026-07-01-qe-cutoff-required.md
@@ -1,0 +1,184 @@
+# QE cutoff required (reject instead of 0.0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When cif2x cannot resolve a QE plane-wave cutoff for an element, raise a clear `InputValidationError` instead of silently generating `ecutwfc = 0.0`.
+
+**Architecture:** `Struct2QE._find_elem_cutoff` is the single per-element resolver that chains the cutoff CSV then the UPF file. Its final `None → 0.0` substitution becomes a raised error naming the element; the dead commented-out `raise`/`logger.error` tail in `_find_elem_cutoff_from_file` is removed since the caller now enforces the requirement.
+
+**Tech Stack:** Python, pytest, pandas, BeautifulSoup (bs4), pymatgen.
+
+---
+
+### Task 1: Reject unresolved cutoffs
+
+**Files:**
+- Modify: `src/cif2x/struct2qe.py` (add import; `_find_elem_cutoff` ~lines 87-101; `_find_elem_cutoff_from_file` tail ~lines 154-157)
+- Test: `tests/test_qe_pp_filename.py` (append)
+
+Context — the current resolver (`src/cif2x/struct2qe.py`):
+
+```python
+    def _find_elem_cutoff(self, ename):
+        ecutwfc, ecutrho = None, None
+
+        if ecutwfc is None or ecutrho is None:
+            ecutwfc, ecutrho = self._find_elem_cutoff_from_table(ename)
+
+        if ecutwfc is None or ecutrho is None:
+            ecutwfc, ecutrho = self._find_elem_cutoff_from_file(ename)
+
+        if ecutwfc is None:
+            ecutwfc = 0.0
+        if ecutrho is None:
+            ecutrho = 0.0
+
+        return ecutwfc, ecutrho
+```
+
+and the dead tail of `_find_elem_cutoff_from_file`:
+
+```python
+        if ecutwfc is None or ecutrho is None:
+            # raise ValueError("cutoff information not found")
+            logger.error("cutoff information not found")
+        return ecutwfc, ecutrho
+```
+
+`_find_elem_cutoff_from_table` returns `(None, None)` when `self.cutoff_list is None`; `_find_elem_cutoff_from_file` returns `(None, None)` when `self.pp_list is None`. Both `_find_elem_cutoff_from_table` and `_pp_filename` read `self.is_soc`. `InputValidationError` (a plain `Exception` subclass) lives in `cif2x.input_validator`, which imports nothing from `cif2x` — no circular-import risk. It is not yet imported in `struct2qe.py`.
+
+- [ ] **Step 1: Write the failing test + regression guards**
+
+Append to `tests/test_qe_pp_filename.py`. Add this import near the top (after the existing `from cif2x.struct2qe import Struct2QE`):
+
+```python
+from cif2x.input_validator import InputValidationError
+```
+
+Then append these tests:
+
+```python
+def test_find_elem_cutoff_missing_raises():
+    # Neither the cutoff CSV nor a UPF file is available: the resolver must
+    # reject with a clear error naming the element, not fall back to 0.0.
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.cutoff_list = None
+    qe.pp_list = None
+    with pytest.raises(InputValidationError, match="Sr"):
+        qe._find_elem_cutoff("Sr")
+
+
+def test_find_elem_cutoff_resolves_from_table():
+    # Regression guard: a CSV hit resolves without error.
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
+                              index=["Fe"])
+    qe.cutoff_list = pd.DataFrame(
+        {"ecutwfc": [40.0], "ecutrho": [320.0]},
+        index=["Fe.pbe-spn-rrkjus_psl.1.0.0.UPF"],
+    )
+    assert qe._find_elem_cutoff("Fe") == (40.0, 320.0)
+
+
+def test_find_elem_cutoff_resolves_from_upf(tmp_path):
+    # Regression guard: a UPF-header hit resolves without error.
+    pytest.importorskip("bs4")
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
+                              index=["Fe"])
+    qe.cutoff_list = None
+    qe.pseudo_dir = str(tmp_path)
+    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
+        '<UPF><PP_HEADER wfc_cutoff="40.0" rho_cutoff="320.0"/></UPF>')
+    assert qe._find_elem_cutoff("Fe") == (40.0, 320.0)
+```
+
+- [ ] **Step 2: Run the tests to verify the new one fails**
+
+Run: `python3 -m pytest tests/test_qe_pp_filename.py -v`
+Expected: `test_find_elem_cutoff_missing_raises` FAILS (it returns `(0.0, 0.0)` instead of raising, so `pytest.raises` reports "DID NOT RAISE"). The two `resolves_*` guards PASS (behavior unchanged).
+
+- [ ] **Step 3: Add the import in struct2qe.py**
+
+In `src/cif2x/struct2qe.py`, after the existing `from cif2x.utils import dryrun_emit` line (line 12), add:
+
+```python
+from cif2x.input_validator import InputValidationError
+```
+
+- [ ] **Step 4: Replace the 0.0 fallback with a raise**
+
+In `src/cif2x/struct2qe.py`, change `_find_elem_cutoff` so its tail reads:
+
+```python
+    def _find_elem_cutoff(self, ename):
+        ecutwfc, ecutrho = None, None
+
+        if ecutwfc is None or ecutrho is None:
+            ecutwfc, ecutrho = self._find_elem_cutoff_from_table(ename)
+
+        if ecutwfc is None or ecutrho is None:
+            ecutwfc, ecutrho = self._find_elem_cutoff_from_file(ename)
+
+        if ecutwfc is None or ecutrho is None:
+            raise InputValidationError(
+                "cutoff information not found for element '{}'. Provide it via "
+                "optional.cutoff_file or set content.system.ecutwfc/ecutrho "
+                "explicitly.".format(ename))
+
+        return ecutwfc, ecutrho
+```
+
+- [ ] **Step 5: Remove the dead tail in `_find_elem_cutoff_from_file`**
+
+In `src/cif2x/struct2qe.py`, change the end of `_find_elem_cutoff_from_file` from:
+
+```python
+        if ecutwfc is None or ecutrho is None:
+            # raise ValueError("cutoff information not found")
+            logger.error("cutoff information not found")
+        return ecutwfc, ecutrho
+```
+
+to:
+
+```python
+        return ecutwfc, ecutrho
+```
+
+Leave the earlier `logger.error(f"{pseudo_file}: {e}")` file-open diagnostic untouched — it points at a specific unreadable file and is still useful.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_qe_pp_filename.py -v`
+Expected: all tests PASS, including `test_find_elem_cutoff_missing_raises`.
+
+- [ ] **Step 7: Run the full suite as a regression guard**
+
+Run: `python3 -m pytest -q`
+Expected: all pass (no sample or test relied on the `0.0` fallback).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cif2x/struct2qe.py tests/test_qe_pp_filename.py
+git commit -m "fix(qe): reject unresolved cutoffs instead of defaulting to 0.0"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "raise when cutoff cannot be resolved, naming the element" → Task 1 Step 4 (raises `InputValidationError` with `ename` and both remedies). ✅
+- "drop the dead commented-out raise/logger.error" → Task 1 Step 5. ✅
+- "import InputValidationError" → Task 1 Step 3. ✅
+- "explicit content / CSV / UPF cases unchanged" → guarded by `test_find_elem_cutoff_resolves_from_table` and `test_find_elem_cutoff_resolves_from_upf`; explicit-content path is not touched because `_find_cutoff_info` is only called when the content key is empty. ✅
+- "full existing suite still green" → Task 1 Step 7. ✅
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows complete code. ✅
+
+**Type consistency:** `_find_elem_cutoff`/`_find_elem_cutoff_from_table`/`_find_elem_cutoff_from_file`/`_pp_filename` names and the `(ecutwfc, ecutrho)` tuple return match the existing code and the tests. `InputValidationError` import path (`cif2x.input_validator`) matches the class location. ✅

--- a/docs/superpowers/specs/2026-07-01-qe-cutoff-required-design.md
+++ b/docs/superpowers/specs/2026-07-01-qe-cutoff-required-design.md
@@ -1,0 +1,83 @@
+# QE cutoff: reject instead of silently defaulting to 0.0 — Design
+
+**Date:** 2026-07-01
+**Status:** approved (pending written-spec review)
+
+## Problem
+
+When cif2x generates a QE input and the plane-wave cutoffs (`ecutwfc`/`ecutrho`)
+are left empty in `content`, it resolves them by, in order: the cutoff CSV
+(`optional.cutoff_file`), then the UPF header / "Suggested" lines. If none of
+these yields a value, `Struct2QE._find_elem_cutoff` silently substitutes `0.0`:
+
+```python
+if ecutwfc is None:
+    ecutwfc = 0.0
+if ecutrho is None:
+    ecutrho = 0.0
+```
+
+and `_find_elem_cutoff_from_file` only logs `"cutoff information not found"`
+(the original `raise` is commented out). The result is a generated `scf.in`
+with `ecutwfc = 0.0` — a silently broken input that QE will reject downstream
+with a confusing error, far from the real cause.
+
+This bites norm-conserving (ONCV/PseudoDojo) pseudopotentials in particular:
+their UPFs frequently do not carry `wfc_cutoff`/`rho_cutoff`, so the cutoff must
+come from the CSV or an explicit `content` value — and if the user forgets,
+today they get `0.0` with no hard failure.
+
+## Goal
+
+Fail loudly at generation time when a required cutoff cannot be resolved,
+instead of emitting `ecutwfc = 0.0`. The error must name the offending
+element(s) and tell the user how to fix it.
+
+## Behavior
+
+`_find_elem_cutoff(ename)` raises `InputValidationError` when, after consulting
+the cutoff table and the UPF file, either `ecutwfc` or `ecutrho` is still
+`None`. Message names the element and both remedies, e.g.:
+
+> cutoff information not found for element 'Sr'. Provide it via
+> `optional.cutoff_file` or set `content.system.ecutwfc`/`ecutrho` explicitly.
+
+Unchanged (all still succeed exactly as before):
+- Explicit `content.system.ecutwfc`/`ecutrho`: `_find_cutoff_info` is only
+  called when those keys are empty, so explicit values never hit this path.
+- Cutoff CSV hit (`_find_elem_cutoff_from_table`).
+- UPF header / "Suggested" line hit (`_find_elem_cutoff_from_file`).
+
+Only the previously-silent "nothing found → 0.0" case changes, and it changes
+from a broken file to a clear error. No existing sample or test relies on the
+`0.0` fallback (verified: every QE sample supplies `cutoff_file` or uses PSL
+UPFs that carry header cutoffs).
+
+## Changes
+
+- `src/cif2x/struct2qe.py`
+  - `_find_elem_cutoff`: replace the `0.0` substitution with a raised
+    `InputValidationError` naming the element when either value is `None`.
+  - `_find_elem_cutoff_from_file`: drop the dead commented-out `raise` /
+    `logger.error("cutoff information not found")` at the end, since the caller
+    now enforces the requirement. Keep the file-open / parse `logger.error`
+    diagnostics that point at a specific file.
+  - Import `InputValidationError` (from `cif2x.input_validator`) if not already.
+- `tests/` — new test module (or add to an existing QE cutoff test file):
+  - cutoff missing from both CSV and UPF → `InputValidationError` naming the
+    element.
+  - cutoff present in CSV → resolves, no error (regression guard).
+  - cutoff present in UPF header → resolves, no error (regression guard).
+
+## Verification
+
+- New tests pass; full existing suite still green (no sample/test depended on
+  the `0.0` fallback).
+- Message names the element and both remedies.
+
+## Out of scope
+
+- The RESPACK tutorial (separate spec, `2026-07-01-respack-tutorial-design.md`)
+  builds on this: it supplies ONCV cutoffs explicitly and relies on this clear
+  error if a reader omits them.
+- Any change to the cutoff-lookup order or the CSV/UPF parsing itself.

--- a/src/cif2x/qe/calc_mode.py
+++ b/src/cif2x/qe/calc_mode.py
@@ -63,9 +63,11 @@ class QEmode_pw(QEmode_base):
         }
 
     def update_namelist(self, content):
-        if "system" not in content.namelist:
+        system = content.namelist.get("system") if content.namelist else None
+        if not isinstance(system, dict):
             # pw.x cannot run without a &system namelist (ecutwfc, nat and
-            # ntyp live there): reject instead of emitting an invalid input
+            # ntyp live there); a bare "system:" in YAML parses to None and
+            # is equally unusable: reject instead of emitting invalid input
             raise InputValidationError(
                 "pw.x input requires a &system namelist; add one to the "
                 "template or content.namelist.system")
@@ -118,7 +120,19 @@ class QEmode_pw(QEmode_base):
         need_rho = is_empty_key(system, "ecutrho") or \
             (wfc_absent and "ecutrho" not in system)
         if need_wfc or need_rho:
-            known_wfc = None if need_wfc else system["ecutwfc"]
+            known_wfc = None
+            if not need_wfc:
+                # the user-supplied value feeds the 4*ecutwfc floor and the
+                # generated input: reject non-numeric values with a clear error
+                try:
+                    known_wfc = float(system["ecutwfc"])
+                except (TypeError, ValueError):
+                    raise InputValidationError(
+                        "content.namelist.system.ecutwfc must be numeric, "
+                        "got {!r}".format(system["ecutwfc"]))
+                # write the normalized number back so a numeric string
+                # ("100") is not rendered as a quoted Fortran string
+                system["ecutwfc"] = known_wfc
             ecutwfc, ecutrho = self.qe._find_cutoff_info(need_wfc, need_rho,
                                                          known_wfc)
             if need_wfc:

--- a/src/cif2x/qe/calc_mode.py
+++ b/src/cif2x/qe/calc_mode.py
@@ -3,6 +3,7 @@ logger = logging.getLogger(__name__)
 
 from .cards import *
 from .tools import *
+from cif2x.input_validator import InputValidationError
 
 def create_modeproc(mode, qe):
     if mode in ["scf", "nscf", "relax", "vc-relax", "bands"]:
@@ -62,8 +63,12 @@ class QEmode_pw(QEmode_base):
         }
 
     def update_namelist(self, content):
-        if not content.namelist:
-            return
+        if "system" not in content.namelist:
+            # pw.x cannot run without a &system namelist (ecutwfc, nat and
+            # ntyp live there): reject instead of emitting an invalid input
+            raise InputValidationError(
+                "pw.x input requires a &system namelist; add one to the "
+                "template or content.namelist.system")
         self._update_struct_info(content)
         self._update_cutoff_info(content)
         self._update_nspin_info(content)
@@ -102,23 +107,29 @@ class QEmode_pw(QEmode_base):
                 content.namelist["system"]["ntyp"] = len(self.qe.struct.atom_types)
 
     def _update_cutoff_info(self, content):
-        if "system" in content.namelist:
-            system = content.namelist["system"]
-            # ecutwfc is mandatory for pw.x: fill it also when the template
-            # omits the key entirely, not only on a blank placeholder
-            need_wfc = system.get("ecutwfc", None) is None
-            need_rho = is_empty_key(system, "ecutrho")
-            if need_wfc or need_rho:
-                ecutwfc, ecutrho = self.qe._find_cutoff_info(need_wfc, need_rho)
-                if need_wfc:
-                    system["ecutwfc"] = ecutwfc
-                if need_rho:
-                    if ecutrho is None:
-                        # ecutrho is optional in QE: drop the placeholder and
-                        # let pw.x default to 4*ecutwfc
-                        del system["ecutrho"]
-                    else:
-                        system["ecutrho"] = ecutrho
+        system = content.namelist["system"]
+        # ecutwfc is mandatory for pw.x: fill it also when the template
+        # omits the key entirely, not only on a blank placeholder
+        wfc_absent = "ecutwfc" not in system
+        need_wfc = wfc_absent or system["ecutwfc"] is None
+        # an absent ecutrho normally means "leave it to pw.x", but when the
+        # template carries no cutoff keys at all it has no say on cutoffs,
+        # so a suggested ecutrho (vital for ultrasoft pseudos) is resolved too
+        need_rho = is_empty_key(system, "ecutrho") or \
+            (wfc_absent and "ecutrho" not in system)
+        if need_wfc or need_rho:
+            known_wfc = None if need_wfc else system["ecutwfc"]
+            ecutwfc, ecutrho = self.qe._find_cutoff_info(need_wfc, need_rho,
+                                                         known_wfc)
+            if need_wfc:
+                system["ecutwfc"] = ecutwfc
+            if need_rho:
+                if ecutrho is None:
+                    # ecutrho is optional in QE: drop the key and let
+                    # pw.x default to 4*ecutwfc
+                    system.pop("ecutrho", None)
+                else:
+                    system["ecutrho"] = ecutrho
 
     def _update_nspin_info(self, content):
         if "system" in content.namelist:

--- a/src/cif2x/qe/calc_mode.py
+++ b/src/cif2x/qe/calc_mode.py
@@ -103,12 +103,15 @@ class QEmode_pw(QEmode_base):
 
     def _update_cutoff_info(self, content):
         if "system" in content.namelist:
-            if is_empty_key(content.namelist["system"], "ecutwfc") or is_empty_key(content.namelist["system"], "ecutrho"):
-                ecutwfc, ecutrho = self.qe._find_cutoff_info()
-                if content.namelist["system"]["ecutwfc"] is None:
-                    content.namelist["system"]["ecutwfc"] = ecutwfc
-                if content.namelist["system"]["ecutrho"] is None:
-                    content.namelist["system"]["ecutrho"] = ecutrho
+            system = content.namelist["system"]
+            need_wfc = is_empty_key(system, "ecutwfc")
+            need_rho = is_empty_key(system, "ecutrho")
+            if need_wfc or need_rho:
+                ecutwfc, ecutrho = self.qe._find_cutoff_info(need_wfc, need_rho)
+                if need_wfc:
+                    system["ecutwfc"] = ecutwfc
+                if need_rho:
+                    system["ecutrho"] = ecutrho
 
     def _update_nspin_info(self, content):
         if "system" in content.namelist:

--- a/src/cif2x/qe/calc_mode.py
+++ b/src/cif2x/qe/calc_mode.py
@@ -104,14 +104,21 @@ class QEmode_pw(QEmode_base):
     def _update_cutoff_info(self, content):
         if "system" in content.namelist:
             system = content.namelist["system"]
-            need_wfc = is_empty_key(system, "ecutwfc")
+            # ecutwfc is mandatory for pw.x: fill it also when the template
+            # omits the key entirely, not only on a blank placeholder
+            need_wfc = system.get("ecutwfc", None) is None
             need_rho = is_empty_key(system, "ecutrho")
             if need_wfc or need_rho:
                 ecutwfc, ecutrho = self.qe._find_cutoff_info(need_wfc, need_rho)
                 if need_wfc:
                     system["ecutwfc"] = ecutwfc
                 if need_rho:
-                    system["ecutrho"] = ecutrho
+                    if ecutrho is None:
+                        # ecutrho is optional in QE: drop the placeholder and
+                        # let pw.x default to 4*ecutwfc
+                        del system["ecutrho"]
+                    else:
+                        system["ecutrho"] = ecutrho
 
     def _update_nspin_info(self, content):
         if "system" in content.namelist:

--- a/src/cif2x/struct2qe.py
+++ b/src/cif2x/struct2qe.py
@@ -79,13 +79,14 @@ class Struct2QE:
             else:
                 content.write_input(filename, Path(dirname, key))
 
-    def _find_cutoff_info(self):
-        cutoffs = [ self._find_elem_cutoff(ename) for ename in self.struct.elem_names ]
-        ecutwfc_max = max([wfc for wfc, _ in cutoffs])
-        ecutrho_max = max([rho for _, rho in cutoffs])
+    def _find_cutoff_info(self, need_wfc=True, need_rho=True):
+        cutoffs = [ self._find_elem_cutoff(ename, need_wfc, need_rho)
+                    for ename in self.struct.elem_names ]
+        ecutwfc_max = max(wfc for wfc, _ in cutoffs) if need_wfc else None
+        ecutrho_max = max(rho for _, rho in cutoffs) if need_rho else None
         return ecutwfc_max, ecutrho_max
 
-    def _find_elem_cutoff(self, ename):
+    def _find_elem_cutoff(self, ename, need_wfc=True, need_rho=True):
         ecutwfc, ecutrho = None, None
 
         if ecutwfc is None or ecutrho is None:
@@ -94,11 +95,16 @@ class Struct2QE:
         if ecutwfc is None or ecutrho is None:
             ecutwfc, ecutrho = self._find_elem_cutoff_from_file(ename)
 
-        if ecutwfc is None or ecutrho is None:
+        if need_wfc and ecutwfc is None:
             raise InputValidationError(
-                "cutoff information not found for element '{}'. Provide it via "
-                "optional.cutoff_file or set content.system.ecutwfc/ecutrho "
-                "explicitly.".format(ename))
+                "cutoff information (ecutwfc) not found for element '{}'. "
+                "Provide it via optional.cutoff_file or set "
+                "content.system.ecutwfc explicitly.".format(ename))
+        if need_rho and ecutrho is None:
+            raise InputValidationError(
+                "cutoff information (ecutrho) not found for element '{}'. "
+                "Provide it via optional.cutoff_file or set "
+                "content.system.ecutrho explicitly.".format(ename))
 
         return ecutwfc, ecutrho
 

--- a/src/cif2x/struct2qe.py
+++ b/src/cif2x/struct2qe.py
@@ -28,6 +28,7 @@ def _normalize_cutoff(value):
     try:
         value = float(value)
     except (TypeError, ValueError):
+        logger.warning(f"unparseable cutoff value {value!r}; treated as unspecified")
         return None
     if np.isnan(value) or value <= 0.0:
         return None
@@ -93,30 +94,44 @@ class Struct2QE:
             else:
                 content.write_input(filename, Path(dirname, key))
 
-    def _find_cutoff_info(self, need_wfc=True, need_rho=True):
+    def _find_cutoff_info(self, need_wfc=True, need_rho=True, known_wfc=None):
         cutoffs = [ self._find_elem_cutoff(ename, need_wfc, need_rho)
                     for ename in self.struct.elem_names ]
         ecutwfc_max = max(wfc for wfc, _ in cutoffs) if need_wfc else None
         ecutrho_max = None
         if need_rho:
-            if all(rho is None for _, rho in cutoffs):
+            suggested = [rho for _, rho in cutoffs if rho is not None]
+            if not suggested:
                 # no pseudopotential suggests a charge-density cutoff (typical
                 # for norm-conserving sets): leave ecutrho to the pw.x default
                 logger.info("ecutrho not suggested by any pseudopotential; "
                             "left to the QE default (4*ecutwfc)")
             else:
-                # elements without a suggested ecutrho fall under QE's default
-                # 4*ecutwfc, which must compete against the suggested values
-                candidates = [rho if rho is not None else 4.0 * wfc
-                              for wfc, rho in cutoffs
-                              if rho is not None or wfc is not None]
-                ecutrho_max = max(candidates)
+                bare = [ename for ename, (_, rho)
+                        in zip(self.struct.elem_names, cutoffs) if rho is None]
+                if bare:
+                    logger.warning("ecutrho not suggested for element(s) {}; "
+                                   "covered by the 4*ecutwfc floor"
+                                   .format(", ".join(bare)))
+                # an explicit ecutrho must never fall below QE's own default,
+                # 4 * the ecutwfc actually written to the input (the resolved
+                # maximum, or the user-supplied value when need_wfc is False)
+                ecutrho_max = max(suggested)
+                final_wfc = ecutwfc_max if need_wfc else known_wfc
+                if final_wfc is not None:
+                    floor = 4.0 * final_wfc
+                    # cutoff CSVs often store a rounded print of exactly
+                    # 4*ecutwfc: keep the stored value over a rounding-level
+                    # difference, lift only when genuinely below the default
+                    if ecutrho_max < floor and \
+                            not np.isclose(ecutrho_max, floor, rtol=1.0e-6):
+                        ecutrho_max = floor
         return ecutwfc_max, ecutrho_max
 
     def _find_elem_cutoff(self, ename, need_wfc=True, need_rho=True):
         ecutwfc, ecutrho = self._find_elem_cutoff_from_table(ename)
 
-        if ecutwfc is None or ecutrho is None:
+        if (need_wfc and ecutwfc is None) or (need_rho and ecutrho is None):
             file_wfc, file_rho = self._find_elem_cutoff_from_file(ename)
             if ecutwfc is None:
                 ecutwfc = file_wfc
@@ -164,7 +179,7 @@ class Struct2QE:
             with open(pseudo_file, "r") as fp:
                 bs = BeautifulSoup(fp, "html.parser")
         except Exception as e:
-            logger.error(f"{pseudo_file}: {e}")
+            logger.warning(f"{pseudo_file}: {e}")
             pass
 
         if bs and bs.upf and bs.upf.pp_header:
@@ -173,13 +188,15 @@ class Struct2QE:
             if bs.upf.pp_header.has_attr("rho_cutoff"):
                 ecutrho = _normalize_cutoff(bs.upf.pp_header["rho_cutoff"])
         if ecutwfc is None or ecutrho is None:
+            # fill only the fields the header did not provide; a "Suggested"
+            # line may itself carry an unset 0.0 and must not clobber them
             if bs and bs.upf and bs.upf.pp_info:
                 lines = str(bs.upf.pp_info).splitlines()
                 sg = [s for s in lines if "Suggested" in s]
                 for s in sg:
-                    if "wavefunctions" in s:
+                    if "wavefunctions" in s and ecutwfc is None:
                         ecutwfc = _normalize_cutoff(s.split()[5])
-                    elif "charge density" in s:
+                    elif "charge density" in s and ecutrho is None:
                         ecutrho = _normalize_cutoff(s.split()[6])
 
         return ecutwfc, ecutrho

--- a/src/cif2x/struct2qe.py
+++ b/src/cif2x/struct2qe.py
@@ -10,6 +10,7 @@ import copy
 
 from cif2x.cif2struct import Cif2Struct
 from cif2x.utils import dryrun_emit
+from cif2x.input_validator import InputValidationError
 from cif2x.qe.tools import *
 from cif2x.qe.qeutil import QEInputGeneral
 from cif2x.qe.content import Content, inflate
@@ -93,11 +94,12 @@ class Struct2QE:
         if ecutwfc is None or ecutrho is None:
             ecutwfc, ecutrho = self._find_elem_cutoff_from_file(ename)
 
-        if ecutwfc is None:
-            ecutwfc = 0.0
-        if ecutrho is None:
-            ecutrho = 0.0
-            
+        if ecutwfc is None or ecutrho is None:
+            raise InputValidationError(
+                "cutoff information not found for element '{}'. Provide it via "
+                "optional.cutoff_file or set content.system.ecutwfc/ecutrho "
+                "explicitly.".format(ename))
+
         return ecutwfc, ecutrho
 
     def _pp_filename(self, ename):
@@ -151,9 +153,6 @@ class Struct2QE:
                     elif "charge density" in s:
                         ecutrho = float(s.split()[6])
 
-        if ecutwfc is None or ecutrho is None:
-            # raise ValueError("cutoff information not found")
-            logger.error("cutoff information not found")
         return ecutwfc, ecutrho
 
     def _set_nspin_info(self, content):

--- a/src/cif2x/struct2qe.py
+++ b/src/cif2x/struct2qe.py
@@ -20,6 +20,20 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _normalize_cutoff(value):
+    # blank CSV cells arrive as NaN and ld1.x-generated UPFs may carry the
+    # cutoff attribute with a literal 0.0; both mean "not specified"
+    if value is None:
+        return None
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+    if np.isnan(value) or value <= 0.0:
+        return None
+    return value
+
+
 class Struct2QE:
     def __init__(self, info, struct):
         logger.debug("__init__")
@@ -83,28 +97,37 @@ class Struct2QE:
         cutoffs = [ self._find_elem_cutoff(ename, need_wfc, need_rho)
                     for ename in self.struct.elem_names ]
         ecutwfc_max = max(wfc for wfc, _ in cutoffs) if need_wfc else None
-        ecutrho_max = max(rho for _, rho in cutoffs) if need_rho else None
+        ecutrho_max = None
+        if need_rho:
+            if all(rho is None for _, rho in cutoffs):
+                # no pseudopotential suggests a charge-density cutoff (typical
+                # for norm-conserving sets): leave ecutrho to the pw.x default
+                logger.info("ecutrho not suggested by any pseudopotential; "
+                            "left to the QE default (4*ecutwfc)")
+            else:
+                # elements without a suggested ecutrho fall under QE's default
+                # 4*ecutwfc, which must compete against the suggested values
+                candidates = [rho if rho is not None else 4.0 * wfc
+                              for wfc, rho in cutoffs
+                              if rho is not None or wfc is not None]
+                ecutrho_max = max(candidates)
         return ecutwfc_max, ecutrho_max
 
     def _find_elem_cutoff(self, ename, need_wfc=True, need_rho=True):
-        ecutwfc, ecutrho = None, None
+        ecutwfc, ecutrho = self._find_elem_cutoff_from_table(ename)
 
         if ecutwfc is None or ecutrho is None:
-            ecutwfc, ecutrho = self._find_elem_cutoff_from_table(ename)
-
-        if ecutwfc is None or ecutrho is None:
-            ecutwfc, ecutrho = self._find_elem_cutoff_from_file(ename)
+            file_wfc, file_rho = self._find_elem_cutoff_from_file(ename)
+            if ecutwfc is None:
+                ecutwfc = file_wfc
+            if ecutrho is None:
+                ecutrho = file_rho
 
         if need_wfc and ecutwfc is None:
             raise InputValidationError(
                 "cutoff information (ecutwfc) not found for element '{}'. "
                 "Provide it via optional.cutoff_file or set "
-                "content.system.ecutwfc explicitly.".format(ename))
-        if need_rho and ecutrho is None:
-            raise InputValidationError(
-                "cutoff information (ecutrho) not found for element '{}'. "
-                "Provide it via optional.cutoff_file or set "
-                "content.system.ecutrho explicitly.".format(ename))
+                "content.namelist.system.ecutwfc explicitly.".format(ename))
 
         return ecutwfc, ecutrho
 
@@ -120,8 +143,8 @@ class Struct2QE:
         if self.cutoff_list is not None and self.pp_list is not None:
             pseudo_file = self._pp_filename(ename)
             if pseudo_file in self.cutoff_list.index:
-                ecutwfc = self.cutoff_list.at[pseudo_file, "ecutwfc"]
-                ecutrho = self.cutoff_list.at[pseudo_file, "ecutrho"]
+                ecutwfc = _normalize_cutoff(self.cutoff_list.at[pseudo_file, "ecutwfc"])
+                ecutrho = _normalize_cutoff(self.cutoff_list.at[pseudo_file, "ecutrho"])
                 logger.debug(f"cutoff: from csv: elem={ename}, ecutwfc={ecutwfc}, ecutrho={ecutrho}")
             else:
                 logger.debug(f"cutoff: from csv: entry not found: {pseudo_file}")
@@ -146,18 +169,18 @@ class Struct2QE:
 
         if bs and bs.upf and bs.upf.pp_header:
             if bs.upf.pp_header.has_attr("wfc_cutoff"):
-                ecutwfc = float(bs.upf.pp_header["wfc_cutoff"])
+                ecutwfc = _normalize_cutoff(bs.upf.pp_header["wfc_cutoff"])
             if bs.upf.pp_header.has_attr("rho_cutoff"):
-                ecutrho = float(bs.upf.pp_header["rho_cutoff"])
+                ecutrho = _normalize_cutoff(bs.upf.pp_header["rho_cutoff"])
         if ecutwfc is None or ecutrho is None:
             if bs and bs.upf and bs.upf.pp_info:
                 lines = str(bs.upf.pp_info).splitlines()
                 sg = [s for s in lines if "Suggested" in s]
                 for s in sg:
                     if "wavefunctions" in s:
-                        ecutwfc = float(s.split()[5])
+                        ecutwfc = _normalize_cutoff(s.split()[5])
                     elif "charge density" in s:
-                        ecutrho = float(s.split()[6])
+                        ecutrho = _normalize_cutoff(s.split()[6])
 
         return ecutwfc, ecutrho
 

--- a/src/utils/pp_cutoff.py
+++ b/src/utils/pp_cutoff.py
@@ -36,8 +36,24 @@ DESCRIPTION
 
 from bs4 import BeautifulSoup
 import csv
+import math
 import logging
 logger = logging.getLogger(__name__)
+
+def _normalize_cutoff(value):
+    # keep in sync with cif2x.struct2qe._normalize_cutoff (this helper stays
+    # standalone, so no import): unset attributes written as 0.0 by ld1.x and
+    # unparseable tokens mean "not specified"
+    if value is None:
+        return None
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        logger.warning("unparseable cutoff value {!r}; treated as unspecified".format(value))
+        return None
+    if math.isnan(value) or value <= 0.0:
+        return None
+    return value
 
 def read_pseudo_cutoff(pp_file, use_header=True):
     ecutwfc = None
@@ -49,7 +65,7 @@ def read_pseudo_cutoff(pp_file, use_header=True):
     except Exception as e:
         logger.error("{}: {}".format(pp_file, e))
         return None
-        
+
     if bs is None or bs.upf is None:
         logger.error("{}: unknown pseudopotential file format".format(pp_file))
         return None
@@ -58,28 +74,33 @@ def read_pseudo_cutoff(pp_file, use_header=True):
         # read cutoff from pp_header attribute
         if bs.upf.pp_header:
             if bs.upf.pp_header.has_attr("wfc_cutoff"):
-                ecutwfc = float(bs.upf.pp_header["wfc_cutoff"])
+                ecutwfc = _normalize_cutoff(bs.upf.pp_header["wfc_cutoff"])
             if bs.upf.pp_header.has_attr("rho_cutoff"):
-                ecutrho = float(bs.upf.pp_header["rho_cutoff"])
+                ecutrho = _normalize_cutoff(bs.upf.pp_header["rho_cutoff"])
         if ecutwfc is None or ecutrho is None:
             logger.warning("{}: cutoff info not found in header".format(pp_file))
 
     if ecutwfc is None or ecutrho is None:
-        # read cutoff from pp_info text description
+        # read cutoff from pp_info text description; fill only the missing
+        # fields so header values survive an unset "Suggested ... 0.0" line
         if bs.upf.pp_info:
             lines = str(bs.upf.pp_info).splitlines()
             sg = [s for s in lines if "Suggested" in s]
             for s in sg:
-                if "wavefunctions" in s:
-                    ecutwfc = float(s.split()[5])
-                elif "charge density" in s:
-                    ecutrho = float(s.split()[6])
+                if "wavefunctions" in s and ecutwfc is None:
+                    ecutwfc = _normalize_cutoff(s.split()[5])
+                elif "charge density" in s and ecutrho is None:
+                    ecutrho = _normalize_cutoff(s.split()[6])
 
-    if ecutwfc is None or ecutrho is None:
-        logger.warning("{}: wfc_cutoff or rho_cutoff not found".format(pp_file))
+    if ecutwfc is None:
+        logger.warning("{}: wfc_cutoff not found".format(pp_file))
         return None
-    else:
-        return [ pp_file, ecutwfc, ecutrho ]
+    if ecutrho is None:
+        # leave the CSV cell blank: cif2x reads it as "not specified" and
+        # omits ecutrho from the input (pw.x then defaults to 4*ecutwfc)
+        logger.warning("{}: rho_cutoff not found; leaving the CSV cell blank".format(pp_file))
+        return [ pp_file, ecutwfc, "" ]
+    return [ pp_file, ecutwfc, ecutrho ]
 
 def main():
     import argparse

--- a/tests/test_pp_cutoff.py
+++ b/tests/test_pp_cutoff.py
@@ -32,6 +32,14 @@ def test_zero_header_cutoff_treated_as_missing(tmp_path):
     assert read_pseudo_cutoff(str(upf)) == [str(upf), 40.0, ""]
 
 
+def test_absent_rho_attribute_yields_blank_cell(tmp_path):
+    # No rho_cutoff anywhere (header or pp_info): the row is still emitted,
+    # with a blank ecutrho cell, instead of dropping the pseudopotential.
+    upf = tmp_path / "Fe.UPF"
+    _write_upf(upf, header_attrs='wfc_cutoff="40.0"')
+    assert read_pseudo_cutoff(str(upf)) == [str(upf), 40.0, ""]
+
+
 def test_missing_wfc_cutoff_returns_none(tmp_path):
     upf = tmp_path / "Fe.UPF"
     _write_upf(upf, header_attrs='rho_cutoff="320.0"')

--- a/tests/test_pp_cutoff.py
+++ b/tests/test_pp_cutoff.py
@@ -1,8 +1,18 @@
+import importlib.util
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip("bs4")
 
-from utils.pp_cutoff import read_pseudo_cutoff
+# src/utils/pp_cutoff.py is a standalone helper script, not part of the
+# installed cif2x distribution, so load it by file path: this works both
+# against the src/ tree and when CIF2X_TEST_INSTALLED tests the wheel.
+_PP_CUTOFF_PATH = Path(__file__).resolve().parent.parent / "src" / "utils" / "pp_cutoff.py"
+_spec = importlib.util.spec_from_file_location("pp_cutoff", _PP_CUTOFF_PATH)
+_pp_cutoff = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_pp_cutoff)
+read_pseudo_cutoff = _pp_cutoff.read_pseudo_cutoff
 
 
 def _write_upf(path, header_attrs="", pp_info=""):

--- a/tests/test_pp_cutoff.py
+++ b/tests/test_pp_cutoff.py
@@ -1,0 +1,41 @@
+import pytest
+
+pytest.importorskip("bs4")
+
+from utils.pp_cutoff import read_pseudo_cutoff
+
+
+def _write_upf(path, header_attrs="", pp_info=""):
+    body = ""
+    if pp_info:
+        body += f"<PP_INFO>\n{pp_info}\n</PP_INFO>"
+    body += f"<PP_HEADER {header_attrs}/>"
+    path.write_text(f"<UPF>{body}</UPF>")
+
+
+def test_zero_header_cutoff_treated_as_missing(tmp_path):
+    # ld1.x-generated UPFs carry rho_cutoff="0.0" when unset: the CSV row must
+    # get a blank cell (which cif2x reads as "not specified"), not a literal
+    # 0.0 that the generator would then reject as "not found".
+    upf = tmp_path / "Fe.UPF"
+    _write_upf(upf, header_attrs='wfc_cutoff="40.0" rho_cutoff="0.0"')
+    assert read_pseudo_cutoff(str(upf)) == [str(upf), 40.0, ""]
+
+
+def test_missing_wfc_cutoff_returns_none(tmp_path):
+    upf = tmp_path / "Fe.UPF"
+    _write_upf(upf, header_attrs='rho_cutoff="320.0"')
+    assert read_pseudo_cutoff(str(upf)) is None
+
+
+def test_pp_info_fills_only_missing_fields(tmp_path):
+    # A valid header wfc_cutoff must survive a pp_info block whose
+    # "Suggested ... wavefunctions" line carries an unset 0.0.
+    upf = tmp_path / "Fe.UPF"
+    _write_upf(
+        upf,
+        header_attrs='wfc_cutoff="40.0"',
+        pp_info=(" Suggested minimum cutoff for wavefunctions:    0.0 Ry\n"
+                 " Suggested minimum cutoff for charge density: 320.0 Ry"),
+    )
+    assert read_pseudo_cutoff(str(upf)) == [str(upf), 40.0, 320.0]

--- a/tests/test_qe_pp_filename.py
+++ b/tests/test_qe_pp_filename.py
@@ -116,3 +116,31 @@ def test_find_elem_cutoff_skips_unneeded_rho(tmp_path):
         '<UPF><PP_HEADER wfc_cutoff="40.0"/></UPF>')
     ecutwfc, ecutrho = qe._find_elem_cutoff("Fe", need_wfc=True, need_rho=False)
     assert ecutwfc == 40.0
+
+
+def test_update_cutoff_info_keeps_user_wfc_and_fills_rho(tmp_path):
+    # Regression: when the user supplies ecutwfc and leaves ecutrho empty,
+    # _update_cutoff_info must keep the user's ecutwfc and fill only ecutrho
+    # from a UPF that exposes only rho_cutoff -- not reject the input.
+    pytest.importorskip("bs4")
+    from types import SimpleNamespace
+    from cif2x.qe.calc_mode import QEmode_pw
+
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
+                              index=["Fe"])
+    qe.cutoff_list = None
+    qe.pseudo_dir = str(tmp_path)
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
+        '<UPF><PP_HEADER rho_cutoff="320.0"/></UPF>')
+
+    mode = QEmode_pw.__new__(QEmode_pw)
+    mode.qe = qe
+    content = SimpleNamespace(
+        namelist={"system": {"ecutwfc": 40.0, "ecutrho": None}})
+    mode._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutwfc"] == 40.0   # user value kept
+    assert content.namelist["system"]["ecutrho"] == 320.0  # filled from UPF

--- a/tests/test_qe_pp_filename.py
+++ b/tests/test_qe_pp_filename.py
@@ -334,6 +334,56 @@ def test_pw_mode_requires_system_namelist():
         _pw_mode(qe).update_namelist(content)
 
 
+def test_pw_mode_rejects_none_namelist():
+    # Content() initializes namelist to None; the &system guard must raise the
+    # clear InputValidationError, not a TypeError from `"system" in None`.
+    from types import SimpleNamespace
+    qe = _qe(False)
+    content = SimpleNamespace(namelist=None, cards=None)
+    with pytest.raises(InputValidationError, match="system"):
+        _pw_mode(qe).update_namelist(content)
+
+
+def test_pw_mode_rejects_non_mapping_system():
+    # YAML "system:" with no body parses to None: it passes a bare membership
+    # check but crashes the update helpers, so reject it like a missing block.
+    from types import SimpleNamespace
+    qe = _qe(False)
+    content = SimpleNamespace(namelist={"system": None}, cards=None)
+    with pytest.raises(InputValidationError, match="system"):
+        _pw_mode(qe).update_namelist(content)
+
+
+def test_numeric_string_ecutwfc_normalized_in_output():
+    # A numeric string ("100") is accepted leniently, but the namelist value
+    # must be written back as a number so f90nml does not quote it.
+    from types import SimpleNamespace
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, 160.0))
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+
+    content = SimpleNamespace(
+        namelist={"system": {"ecutwfc": "100", "ecutrho": None}})
+    _pw_mode(qe)._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutwfc"] == 100.0
+    assert isinstance(content.namelist["system"]["ecutwfc"], float)
+    assert content.namelist["system"]["ecutrho"] == 400.0
+
+
+def test_non_numeric_user_ecutwfc_rejected():
+    # A non-numeric user value reaching the 4*ecutwfc floor must produce a
+    # clear InputValidationError, not a TypeError from 4.0 * "80 Ry"
+    # (numeric strings like "100" are accepted leniently via float()).
+    from types import SimpleNamespace
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, 160.0))
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+
+    content = SimpleNamespace(
+        namelist={"system": {"ecutwfc": "80 Ry", "ecutrho": None}})
+    with pytest.raises(InputValidationError, match="ecutwfc"):
+        _pw_mode(qe)._update_cutoff_info(content)
+
+
 def test_file_fallback_skipped_when_missing_field_not_needed():
     # ecutrho supplied by the user (need_rho=False) and ecutwfc resolved from
     # the CSV: the UPF file must not be opened just because the CSV rho cell

--- a/tests/test_qe_pp_filename.py
+++ b/tests/test_qe_pp_filename.py
@@ -84,3 +84,35 @@ def test_find_elem_cutoff_resolves_from_upf(tmp_path):
     (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
         '<UPF><PP_HEADER wfc_cutoff="40.0" rho_cutoff="320.0"/></UPF>')
     assert qe._find_elem_cutoff("Fe") == (40.0, 320.0)
+
+
+def test_find_elem_cutoff_skips_unneeded_wfc(tmp_path):
+    # ecutwfc supplied by the user (need_wfc=False): a UPF exposing only
+    # rho_cutoff must resolve ecutrho without raising for the absent wfc.
+    pytest.importorskip("bs4")
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
+                              index=["Fe"])
+    qe.cutoff_list = None
+    qe.pseudo_dir = str(tmp_path)
+    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
+        '<UPF><PP_HEADER rho_cutoff="320.0"/></UPF>')
+    ecutwfc, ecutrho = qe._find_elem_cutoff("Fe", need_wfc=False, need_rho=True)
+    assert ecutrho == 320.0
+
+
+def test_find_elem_cutoff_skips_unneeded_rho(tmp_path):
+    # ecutrho supplied by the user (need_rho=False): a UPF exposing only
+    # wfc_cutoff must resolve ecutwfc without raising for the absent rho.
+    pytest.importorskip("bs4")
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
+                              index=["Fe"])
+    qe.cutoff_list = None
+    qe.pseudo_dir = str(tmp_path)
+    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
+        '<UPF><PP_HEADER wfc_cutoff="40.0"/></UPF>')
+    ecutwfc, ecutrho = qe._find_elem_cutoff("Fe", need_wfc=True, need_rho=False)
+    assert ecutwfc == 40.0

--- a/tests/test_qe_pp_filename.py
+++ b/tests/test_qe_pp_filename.py
@@ -6,31 +6,49 @@ pd = pytest.importorskip("pandas")
 from cif2x.struct2qe import Struct2QE
 from cif2x.input_validator import InputValidationError
 
+FE_PP = "pbe-spn-rrkjus_psl.1.0.0"
+FE_UPF = f"Fe.{FE_PP}.UPF"
 
-def _qe(is_soc):
+
+def _qe(is_soc=False, cutoff_list=None, pseudo_dir=None):
     qe = Struct2QE.__new__(Struct2QE)
-    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
-                              index=["Fe"])
     qe.is_soc = is_soc
+    qe.pp_list = pd.DataFrame({"pseudopotential": [FE_PP]}, index=["Fe"])
+    qe.cutoff_list = cutoff_list
+    if pseudo_dir is not None:
+        qe.pseudo_dir = str(pseudo_dir)
     return qe
 
 
+def _fe_cutoff_csv(ecutwfc, ecutrho, name=FE_UPF):
+    return pd.DataFrame({"ecutwfc": [ecutwfc], "ecutrho": [ecutrho]},
+                        index=[name])
+
+
+def _write_upf(dirname, header_attrs, name=FE_UPF):
+    (dirname / name).write_text(f'<UPF><PP_HEADER {header_attrs}/></UPF>')
+
+
+def _pw_mode(qe):
+    from cif2x.qe.calc_mode import QEmode_pw
+    mode = QEmode_pw.__new__(QEmode_pw)
+    mode.qe = qe
+    return mode
+
+
 def test_pp_filename_non_soc():
-    assert _qe(False)._pp_filename("Fe") == "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF"
+    assert _qe(False)._pp_filename("Fe") == FE_UPF
 
 
 def test_pp_filename_soc_has_rel_prefix():
-    assert _qe(True)._pp_filename("Fe") == "Fe.rel-pbe-spn-rrkjus_psl.1.0.0.UPF"
+    assert _qe(True)._pp_filename("Fe") == f"Fe.rel-{FE_PP}.UPF"
 
 
 def test_cutoff_table_lookup_uses_soc_filename():
     # the cutoff CSV is keyed by the actual (rel-) pseudopotential filename for
     # SOC runs; the lookup must use the same name the generator writes
-    qe = _qe(True)
-    qe.cutoff_list = pd.DataFrame(
-        {"ecutwfc": [40.0], "ecutrho": [320.0]},
-        index=["Fe.rel-pbe-spn-rrkjus_psl.1.0.0.UPF"],
-    )
+    qe = _qe(True, cutoff_list=_fe_cutoff_csv(40.0, 320.0,
+                                              name=f"Fe.rel-{FE_PP}.UPF"))
     ecutwfc, ecutrho = qe._find_elem_cutoff_from_table("Fe")
     assert ecutwfc == 40.0
     assert ecutrho == 320.0
@@ -38,10 +56,9 @@ def test_cutoff_table_lookup_uses_soc_filename():
 
 def test_cutoff_file_lookup_uses_soc_filename(tmp_path):
     pytest.importorskip("bs4")
-    qe = _qe(True)
-    qe.pseudo_dir = str(tmp_path)
-    upf = tmp_path / "Fe.rel-pbe-spn-rrkjus_psl.1.0.0.UPF"
-    upf.write_text('<UPF><PP_HEADER wfc_cutoff="40.0" rho_cutoff="320.0"/></UPF>')
+    qe = _qe(True, pseudo_dir=tmp_path)
+    _write_upf(tmp_path, 'wfc_cutoff="40.0" rho_cutoff="320.0"',
+               name=f"Fe.rel-{FE_PP}.UPF")
 
     ecutwfc, ecutrho = qe._find_elem_cutoff_from_file("Fe")
     assert ecutwfc == 40.0
@@ -50,39 +67,28 @@ def test_cutoff_file_lookup_uses_soc_filename(tmp_path):
 
 def test_find_elem_cutoff_missing_raises():
     # Neither the cutoff CSV nor a UPF file is available: the resolver must
-    # reject with a clear error naming the element, not fall back to 0.0.
+    # reject with a clear error naming the element and the real YAML remedy
+    # (content.namelist.system.ecutwfc), not fall back to 0.0.
     qe = Struct2QE.__new__(Struct2QE)
     qe.is_soc = False
     qe.cutoff_list = None
     qe.pp_list = None
-    with pytest.raises(InputValidationError, match="Sr"):
+    with pytest.raises(InputValidationError,
+                       match=r"Sr.*content\.namelist\.system\.ecutwfc"):
         qe._find_elem_cutoff("Sr")
 
 
 def test_find_elem_cutoff_resolves_from_table():
     # Regression guard: a CSV hit resolves without error.
-    qe = Struct2QE.__new__(Struct2QE)
-    qe.is_soc = False
-    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
-                              index=["Fe"])
-    qe.cutoff_list = pd.DataFrame(
-        {"ecutwfc": [40.0], "ecutrho": [320.0]},
-        index=["Fe.pbe-spn-rrkjus_psl.1.0.0.UPF"],
-    )
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, 320.0))
     assert qe._find_elem_cutoff("Fe") == (40.0, 320.0)
 
 
 def test_find_elem_cutoff_resolves_from_upf(tmp_path):
     # Regression guard: a UPF-header hit resolves without error.
     pytest.importorskip("bs4")
-    qe = Struct2QE.__new__(Struct2QE)
-    qe.is_soc = False
-    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
-                              index=["Fe"])
-    qe.cutoff_list = None
-    qe.pseudo_dir = str(tmp_path)
-    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
-        '<UPF><PP_HEADER wfc_cutoff="40.0" rho_cutoff="320.0"/></UPF>')
+    qe = _qe(pseudo_dir=tmp_path)
+    _write_upf(tmp_path, 'wfc_cutoff="40.0" rho_cutoff="320.0"')
     assert qe._find_elem_cutoff("Fe") == (40.0, 320.0)
 
 
@@ -90,14 +96,8 @@ def test_find_elem_cutoff_skips_unneeded_wfc(tmp_path):
     # ecutwfc supplied by the user (need_wfc=False): a UPF exposing only
     # rho_cutoff must resolve ecutrho without raising for the absent wfc.
     pytest.importorskip("bs4")
-    qe = Struct2QE.__new__(Struct2QE)
-    qe.is_soc = False
-    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
-                              index=["Fe"])
-    qe.cutoff_list = None
-    qe.pseudo_dir = str(tmp_path)
-    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
-        '<UPF><PP_HEADER rho_cutoff="320.0"/></UPF>')
+    qe = _qe(pseudo_dir=tmp_path)
+    _write_upf(tmp_path, 'rho_cutoff="320.0"')
     ecutwfc, ecutrho = qe._find_elem_cutoff("Fe", need_wfc=False, need_rho=True)
     assert ecutrho == 320.0
 
@@ -106,16 +106,111 @@ def test_find_elem_cutoff_skips_unneeded_rho(tmp_path):
     # ecutrho supplied by the user (need_rho=False): a UPF exposing only
     # wfc_cutoff must resolve ecutwfc without raising for the absent rho.
     pytest.importorskip("bs4")
-    qe = Struct2QE.__new__(Struct2QE)
-    qe.is_soc = False
-    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
-                              index=["Fe"])
-    qe.cutoff_list = None
-    qe.pseudo_dir = str(tmp_path)
-    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
-        '<UPF><PP_HEADER wfc_cutoff="40.0"/></UPF>')
+    qe = _qe(pseudo_dir=tmp_path)
+    _write_upf(tmp_path, 'wfc_cutoff="40.0"')
     ecutwfc, ecutrho = qe._find_elem_cutoff("Fe", need_wfc=True, need_rho=False)
     assert ecutwfc == 40.0
+
+
+def test_cutoff_table_blank_cell_treated_as_missing():
+    # A blank cell in the cutoff CSV is read by pandas as NaN; it must be
+    # reported as "missing" (None), not propagated into the QE input.
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, float("nan")))
+    ecutwfc, ecutrho = qe._find_elem_cutoff_from_table("Fe")
+    assert ecutwfc == 40.0
+    assert ecutrho is None
+
+
+def test_cutoff_blank_csv_cell_falls_back_to_upf_per_field(tmp_path):
+    # Only the blank (NaN) CSV field falls back to the UPF header; the value
+    # present in the CSV wins over the UPF one.
+    pytest.importorskip("bs4")
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, float("nan")),
+             pseudo_dir=tmp_path)
+    _write_upf(tmp_path, 'wfc_cutoff="60.0" rho_cutoff="320.0"')
+    assert qe._find_elem_cutoff("Fe") == (40.0, 320.0)
+
+
+def test_upf_zero_cutoff_treated_as_missing(tmp_path):
+    # ld1.x-generated UPFs may carry wfc_cutoff="0.0" (attribute present but
+    # unset); 0.0 must be rejected as unresolved, not written into the input.
+    pytest.importorskip("bs4")
+    qe = _qe(pseudo_dir=tmp_path)
+    _write_upf(tmp_path, 'wfc_cutoff="0.000000000000000E+000"'
+                         ' rho_cutoff="0.000000000000000E+000"')
+    with pytest.raises(InputValidationError, match="ecutwfc"):
+        qe._find_elem_cutoff("Fe")
+
+
+def test_unresolved_rho_returns_none_instead_of_raising(tmp_path):
+    # ecutrho is optional in QE (defaults to 4*ecutwfc): an unresolvable rho
+    # cutoff yields None so the key can be omitted, rather than a hard error.
+    pytest.importorskip("bs4")
+    qe = _qe(pseudo_dir=tmp_path)
+    _write_upf(tmp_path, 'wfc_cutoff="40.0"')
+    assert qe._find_elem_cutoff("Fe") == (40.0, None)
+
+
+def test_find_cutoff_info_omits_rho_when_no_pseudo_suggests_one(tmp_path):
+    # Pure norm-conserving set: no pseudopotential suggests ecutrho, so the
+    # aggregate must be (max wfc, None) and the key gets left to pw.x.
+    pytest.importorskip("bs4")
+    from types import SimpleNamespace
+    qe = _qe(pseudo_dir=tmp_path)
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+    _write_upf(tmp_path, 'wfc_cutoff="40.0"')
+    assert qe._find_cutoff_info() == (40.0, None)
+
+
+def test_find_cutoff_info_mixed_rho_covers_default_of_bare_elements(tmp_path):
+    # One pseudo suggests ecutrho, another does not: the element without a
+    # suggestion needs QE's default 4*ecutwfc, so the aggregate takes
+    # max(suggested rho, 4*wfc of the bare elements) = max(160, 4*50) = 200.
+    from types import SimpleNamespace
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pseudo_dir = str(tmp_path)  # no UPF files; CSV is the only source
+    qe.pp_list = pd.DataFrame(
+        {"pseudopotential": ["pbe-a", "pbe-b"]}, index=["Fe", "Sr"])
+    qe.cutoff_list = pd.DataFrame(
+        {"ecutwfc": [40.0, 50.0], "ecutrho": [160.0, float("nan")]},
+        index=["Fe.pbe-a.UPF", "Sr.pbe-b.UPF"],
+    )
+    qe.struct = SimpleNamespace(elem_names=["Fe", "Sr"])
+    assert qe._find_cutoff_info() == (50.0, 200.0)
+
+
+def test_update_cutoff_info_fills_ecutwfc_absent_from_template():
+    # pw.x requires ecutwfc: a template lacking the key entirely must still
+    # get it filled, not silently produce an input without it.
+    from types import SimpleNamespace
+
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, 320.0))
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+
+    content = SimpleNamespace(namelist={"system": {"ecutrho": None}})
+    _pw_mode(qe)._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutwfc"] == 40.0
+    assert content.namelist["system"]["ecutrho"] == 320.0
+
+
+def test_update_cutoff_info_drops_unresolved_rho_placeholder(tmp_path):
+    # Blank ecutrho placeholder + no resolvable rho: the key must be removed
+    # from the namelist so pw.x applies its 4*ecutwfc default.
+    pytest.importorskip("bs4")
+    from types import SimpleNamespace
+
+    qe = _qe(pseudo_dir=tmp_path)
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+    _write_upf(tmp_path, 'wfc_cutoff="40.0"')
+
+    content = SimpleNamespace(
+        namelist={"system": {"ecutwfc": None, "ecutrho": None}})
+    _pw_mode(qe)._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutwfc"] == 40.0
+    assert "ecutrho" not in content.namelist["system"]
 
 
 def test_update_cutoff_info_keeps_user_wfc_and_fills_rho(tmp_path):
@@ -124,23 +219,14 @@ def test_update_cutoff_info_keeps_user_wfc_and_fills_rho(tmp_path):
     # from a UPF that exposes only rho_cutoff -- not reject the input.
     pytest.importorskip("bs4")
     from types import SimpleNamespace
-    from cif2x.qe.calc_mode import QEmode_pw
 
-    qe = Struct2QE.__new__(Struct2QE)
-    qe.is_soc = False
-    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
-                              index=["Fe"])
-    qe.cutoff_list = None
-    qe.pseudo_dir = str(tmp_path)
+    qe = _qe(pseudo_dir=tmp_path)
     qe.struct = SimpleNamespace(elem_names=["Fe"])
-    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
-        '<UPF><PP_HEADER rho_cutoff="320.0"/></UPF>')
+    _write_upf(tmp_path, 'rho_cutoff="320.0"')
 
-    mode = QEmode_pw.__new__(QEmode_pw)
-    mode.qe = qe
     content = SimpleNamespace(
         namelist={"system": {"ecutwfc": 40.0, "ecutrho": None}})
-    mode._update_cutoff_info(content)
+    _pw_mode(qe)._update_cutoff_info(content)
 
     assert content.namelist["system"]["ecutwfc"] == 40.0   # user value kept
     assert content.namelist["system"]["ecutrho"] == 320.0  # filled from UPF

--- a/tests/test_qe_pp_filename.py
+++ b/tests/test_qe_pp_filename.py
@@ -162,10 +162,12 @@ def test_find_cutoff_info_omits_rho_when_no_pseudo_suggests_one(tmp_path):
     assert qe._find_cutoff_info() == (40.0, None)
 
 
-def test_find_cutoff_info_mixed_rho_covers_default_of_bare_elements(tmp_path):
+def test_find_cutoff_info_mixed_rho_covers_default_of_bare_elements(tmp_path, caplog):
     # One pseudo suggests ecutrho, another does not: the element without a
     # suggestion needs QE's default 4*ecutwfc, so the aggregate takes
-    # max(suggested rho, 4*wfc of the bare elements) = max(160, 4*50) = 200.
+    # max(suggested rho, 4*resolved ecutwfc) = max(160, 4*50) = 200, and the
+    # bare element is called out in a warning.
+    import logging
     from types import SimpleNamespace
     qe = Struct2QE.__new__(Struct2QE)
     qe.is_soc = False
@@ -177,7 +179,10 @@ def test_find_cutoff_info_mixed_rho_covers_default_of_bare_elements(tmp_path):
         index=["Fe.pbe-a.UPF", "Sr.pbe-b.UPF"],
     )
     qe.struct = SimpleNamespace(elem_names=["Fe", "Sr"])
-    assert qe._find_cutoff_info() == (50.0, 200.0)
+    with caplog.at_level(logging.WARNING, logger="cif2x.struct2qe"):
+        assert qe._find_cutoff_info() == (50.0, 200.0)
+    assert any("Sr" in r.message and "ecutrho" in r.message
+               for r in caplog.records)
 
 
 def test_update_cutoff_info_fills_ecutwfc_absent_from_template():
@@ -211,6 +216,131 @@ def test_update_cutoff_info_drops_unresolved_rho_placeholder(tmp_path):
 
     assert content.namelist["system"]["ecutwfc"] == 40.0
     assert "ecutrho" not in content.namelist["system"]
+
+
+def test_rho_competition_floored_by_user_ecutwfc(tmp_path):
+    # The emitted ecutrho must never fall below QE's own default, which is
+    # 4 * the ecutwfc actually written -- here the user's 100, not the
+    # pseudopotentials' suggested 40/50.
+    from types import SimpleNamespace
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pseudo_dir = str(tmp_path)  # no UPF files; CSV is the only source
+    qe.pp_list = pd.DataFrame(
+        {"pseudopotential": ["pbe-a", "pbe-b"]}, index=["Fe", "Sr"])
+    qe.cutoff_list = pd.DataFrame(
+        {"ecutwfc": [40.0, 50.0], "ecutrho": [float("nan"), 160.0]},
+        index=["Fe.pbe-a.UPF", "Sr.pbe-b.UPF"],
+    )
+    qe.struct = SimpleNamespace(elem_names=["Fe", "Sr"])
+
+    content = SimpleNamespace(
+        namelist={"system": {"ecutwfc": 100.0, "ecutrho": None}})
+    _pw_mode(qe)._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutwfc"] == 100.0
+    assert content.namelist["system"]["ecutrho"] == 400.0
+
+
+def test_rho_floor_tolerates_csv_rounding():
+    # Cutoff CSVs often store ecutrho as a rounded print of exactly 4*ecutwfc;
+    # the floor must not replace such a value over a last-digit difference
+    # (the sample scf.in_ref fixtures compare cutoffs textually).
+    from types import SimpleNamespace
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.7227652304711, 162.891060921884))
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+
+    content = SimpleNamespace(
+        namelist={"system": {"ecutwfc": None, "ecutrho": None}})
+    _pw_mode(qe)._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutrho"] == 162.891060921884
+
+
+def test_rho_suggested_above_floor_wins():
+    # A suggested ecutrho larger than the 4*ecutwfc floor is kept as-is.
+    from types import SimpleNamespace
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, 500.0))
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+
+    content = SimpleNamespace(
+        namelist={"system": {"ecutwfc": 100.0, "ecutrho": None}})
+    _pw_mode(qe)._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutrho"] == 500.0
+
+
+def test_update_cutoff_info_resolves_rho_when_no_cutoff_keys():
+    # Template carries no cutoff keys at all: not only the mandatory ecutwfc
+    # but also a suggested ecutrho (vital for ultrasoft pseudos) must be
+    # resolved and written, not silently left to pw.x's 4*ecutwfc default.
+    from types import SimpleNamespace
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, 320.0))
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+
+    content = SimpleNamespace(namelist={"system": {"occupations": "smearing"}})
+    _pw_mode(qe)._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutwfc"] == 40.0
+    assert content.namelist["system"]["ecutrho"] == 320.0
+
+
+def test_update_cutoff_info_no_cutoff_keys_and_unresolved_rho(tmp_path):
+    # Template has no cutoff keys and no pseudo suggests ecutrho: ecutwfc is
+    # filled and no ecutrho key is invented (must not raise on the absent key).
+    pytest.importorskip("bs4")
+    from types import SimpleNamespace
+    qe = _qe(pseudo_dir=tmp_path)
+    qe.struct = SimpleNamespace(elem_names=["Fe"])
+    _write_upf(tmp_path, 'wfc_cutoff="40.0"')
+
+    content = SimpleNamespace(namelist={"system": {"occupations": "smearing"}})
+    _pw_mode(qe)._update_cutoff_info(content)
+
+    assert content.namelist["system"]["ecutwfc"] == 40.0
+    assert "ecutrho" not in content.namelist["system"]
+
+
+def test_pp_info_fills_only_missing_fields(tmp_path):
+    # A valid header wfc_cutoff must not be overwritten by the pp_info
+    # "Suggested" fallback (which may carry an unset 0.0); only the field
+    # missing from the header is filled from pp_info.
+    pytest.importorskip("bs4")
+    qe = _qe(pseudo_dir=tmp_path)
+    (tmp_path / FE_UPF).write_text(
+        '<UPF><PP_INFO>\n'
+        ' Suggested minimum cutoff for wavefunctions:    0.0 Ry\n'
+        ' Suggested minimum cutoff for charge density: 320.0 Ry\n'
+        '</PP_INFO><PP_HEADER wfc_cutoff="40.0"/></UPF>')
+    assert qe._find_elem_cutoff_from_file("Fe") == (40.0, 320.0)
+
+
+def test_normalize_cutoff_warns_on_unparseable_value(caplog):
+    import logging
+    from cif2x.struct2qe import _normalize_cutoff
+    with caplog.at_level(logging.WARNING, logger="cif2x.struct2qe"):
+        assert _normalize_cutoff("garbage") is None
+    assert any("garbage" in r.message for r in caplog.records)
+
+
+def test_pw_mode_requires_system_namelist():
+    # scf/nscf inputs cannot be valid without a &system namelist (ecutwfc,
+    # nat, ntyp live there): reject at generation time instead of emitting
+    # an input pw.x cannot run.
+    from types import SimpleNamespace
+    qe = _qe(False)
+    content = SimpleNamespace(namelist={"control": {}}, cards={})
+    with pytest.raises(InputValidationError, match="system"):
+        _pw_mode(qe).update_namelist(content)
+
+
+def test_file_fallback_skipped_when_missing_field_not_needed():
+    # ecutrho supplied by the user (need_rho=False) and ecutwfc resolved from
+    # the CSV: the UPF file must not be opened just because the CSV rho cell
+    # is blank (pseudo_dir is unset here, so an attempted read would raise).
+    qe = _qe(cutoff_list=_fe_cutoff_csv(40.0, float("nan")))
+    ecutwfc, ecutrho = qe._find_elem_cutoff("Fe", need_wfc=True, need_rho=False)
+    assert ecutwfc == 40.0
 
 
 def test_update_cutoff_info_keeps_user_wfc_and_fills_rho(tmp_path):

--- a/tests/test_qe_pp_filename.py
+++ b/tests/test_qe_pp_filename.py
@@ -4,6 +4,7 @@ pytest.importorskip("qe_tools")
 pd = pytest.importorskip("pandas")
 
 from cif2x.struct2qe import Struct2QE
+from cif2x.input_validator import InputValidationError
 
 
 def _qe(is_soc):
@@ -45,3 +46,41 @@ def test_cutoff_file_lookup_uses_soc_filename(tmp_path):
     ecutwfc, ecutrho = qe._find_elem_cutoff_from_file("Fe")
     assert ecutwfc == 40.0
     assert ecutrho == 320.0
+
+
+def test_find_elem_cutoff_missing_raises():
+    # Neither the cutoff CSV nor a UPF file is available: the resolver must
+    # reject with a clear error naming the element, not fall back to 0.0.
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.cutoff_list = None
+    qe.pp_list = None
+    with pytest.raises(InputValidationError, match="Sr"):
+        qe._find_elem_cutoff("Sr")
+
+
+def test_find_elem_cutoff_resolves_from_table():
+    # Regression guard: a CSV hit resolves without error.
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
+                              index=["Fe"])
+    qe.cutoff_list = pd.DataFrame(
+        {"ecutwfc": [40.0], "ecutrho": [320.0]},
+        index=["Fe.pbe-spn-rrkjus_psl.1.0.0.UPF"],
+    )
+    assert qe._find_elem_cutoff("Fe") == (40.0, 320.0)
+
+
+def test_find_elem_cutoff_resolves_from_upf(tmp_path):
+    # Regression guard: a UPF-header hit resolves without error.
+    pytest.importorskip("bs4")
+    qe = Struct2QE.__new__(Struct2QE)
+    qe.is_soc = False
+    qe.pp_list = pd.DataFrame({"pseudopotential": ["pbe-spn-rrkjus_psl.1.0.0"]},
+                              index=["Fe"])
+    qe.cutoff_list = None
+    qe.pseudo_dir = str(tmp_path)
+    (tmp_path / "Fe.pbe-spn-rrkjus_psl.1.0.0.UPF").write_text(
+        '<UPF><PP_HEADER wfc_cutoff="40.0" rho_cutoff="320.0"/></UPF>')
+    assert qe._find_elem_cutoff("Fe") == (40.0, 320.0)


### PR DESCRIPTION
## Summary

Make the QE input generator handle unresolvable cutoffs (ecutwfc/ecutrho) explicitly instead of silently writing 0.0 into the generated input.

The first commits (ba4b6c2, 70bbec9, f0595f0) implement the rejection of unresolved cutoffs; the follow-up commits (0bfeeef, b5771ae) fix the gaps found by two code-review rounds tracked in #13.

Closes #13

## Changes

### Reject unresolved cutoffs (ba4b6c2 ...)
- `_find_elem_cutoff` raises `InputValidationError` instead of falling back to 0.0 when neither the cutoff CSV nor the UPF header resolves a cutoff.
- Only the fields the user did not supply via `content:` are resolved (`need_wfc`/`need_rho`).

### First review round (0bfeeef, #13)
- Normalize blank CSV cells (pandas NaN) and literal-0.0 UPF header attributes (common in ld1.x-generated files) to "not specified" (`_normalize_cutoff`). Previously they slipped past the `is None` checks and `ecutrho = NaN` / `ecutwfc = 0.0` ended up in the generated input.
- When the CSV provides only one field, fill just the missing one from the UPF header instead of overwriting both.
- Fill `ecutwfc` also when the template omits the key entirely: it is mandatory for pw.x, and the input used to be written without it.
- **Omit `ecutrho` when it cannot be resolved** and let pw.x apply its own default (4*ecutwfc). It is optional in QE and normally absent for norm-conserving sets, so only `ecutwfc` remains a hard error.
- Point the error remedy at the real YAML path `content.namelist.system.ecutwfc` (`content.system.*` would be treated as a card).

### Second review round (b5771ae, #13 comment)
- **Floor an explicitly written `ecutrho` at 4 * the ecutwfc actually emitted** (the resolved maximum, or the user-supplied value), so it never falls below the default pw.x would have chosen; rounding-level differences are tolerated so CSVs storing a rounded 4*ecutwfc keep their value.
- When the template carries no cutoff keys at all, resolve `ecutrho` too: filling only `ecutwfc` left ultrasoft sets running on the 4*ecutwfc default instead of the suggested ~8-12x.
- Fill only header-missing fields from the pp_info "Suggested" lines; an unset "0.0 Ry" line could reset a valid header `wfc_cutoff` to None and turn a resolvable pseudopotential into a hard error.
- Warn on unparseable cutoff values and on elements excluded from the ecutrho competition (both were silent).
- Reject pw.x tasks without a `&system` namelist instead of writing an input pw.x cannot run.
- Consult the UPF file only when a needed field is unresolved, and log an open failure as a warning: successful runs no longer emit ERROR noise.
- Align `utils/pp_cutoff.py` with the runtime convention: normalize 0.0/unparseable header values and emit a blank CSV cell (instead of dropping the row) when only `rho_cutoff` is missing.

## Verification

- `pytest tests/` → 261 passed (all fixes were implemented test-first).
- End-to-end CLI runs on `sample/cif2x/qe/NaCl`:
  - default case: generated cutoffs match `scf.in_ref`
  - blank ecutrho CSV cell: the `ecutrho` line is omitted, `ecutwfc` keeps the CSV value
  - missing cutoff row: clean one-line error with the correct remedy, exit 1, no file written
  - template without `ecutwfc:`: filled from the CSV; with `ecutwfc: 100` supplied, `ecutrho = 400` (the 4*ecutwfc floor)
  - task without `&system`: rejected with exit 1

Note: the QE test modules skip silently when `qe_tools` is unavailable; running them locally requires `qe-tools<2` (2.x removed `qe_tools.parsers.qeinputparser`; pyproject pins `^1.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
