### PR TITLE
docs: make both Sphinx trees build warning-free

### DIFF
--- a/docs/en/source/cif2x/tutorial/index.rst
+++ b/docs/en/source/cif2x/tutorial/index.rst
@@ -59,6 +59,7 @@ Run ``cif2x`` and a set of input files for Quantum ESPRESSO will be created. The
 
 .. literalinclude:: ../../../../tutorial/cif2x/scf/scf.in
    :language: fortran
+   :force:
 
 One can confirm that the cutoff values ``ecutwfc`` and ``ecutrho`` are obtained from the pseudo-potential files, that ``CELL_PARAMETERS``, ``ATOMIC_POSITIONS`` and the species in ``ATOMIC_SPECIES`` are derived from the crystal structure data, that the pseudo-potential file names in ``ATOMIC_SPECIES`` are taken from the ``optional.pp_file`` mapping, and that ``K_POINTS`` is generated from the ``content.K_POINTS`` setting (``grid: [8,8,8]`` in this example).
 
@@ -174,6 +175,7 @@ The SCF input file is written to ``scf/scf.in``:
 
 .. literalinclude:: ../../../../tutorial/cif2x/respack/scf/scf.in
    :language: fortran
+   :force:
 
 In the NSCF input file ``nscf/nscf.in``, ``calculation = 'nscf'`` is set together with ``nosym``, ``noinv``, and ``nbnd``, and ``K_POINTS crystal`` lists all k-points explicitly (the k-point list is omitted here for brevity).
 

--- a/docs/en/source/getcif/index.rst
+++ b/docs/en/source/getcif/index.rst
@@ -5,7 +5,6 @@ A tool to retrieve crystallographic data from databases (getcif)
 
 .. toctree::
    :maxdepth: 2
-   :numbered: 2
 
    about/index
    tutorial/index

--- a/docs/ja/source/cif2x/command/index.rst
+++ b/docs/ja/source/cif2x/command/index.rst
@@ -56,7 +56,7 @@ cif2x
 
   - ``--mp-id`` *ID*
 
-    ``material.cif`` を読む代わりに、Materials Project の物質 ID *ID*(例: ``mp-149``)の結晶構造を直接取得します。``material.cif`` と ``--mp-id`` はいずれか一方のみを指定してください。API キーは ``--api-key-file``(既定 ``materials_project.key``)、続いて環境変数 ``MP_API_KEY``、pymatgen 設定ファイル(``~/.config/.pmgrc.yaml``)の ``PMG_MAPI_KEY`` の順に、``getcif`` と同じ方法で解決されます。
+    ``material.cif`` を読む代わりに、Materials Project の物質 ID *ID* (例: ``mp-149``)の結晶構造を直接取得します。``material.cif`` と ``--mp-id`` はいずれか一方のみを指定してください。API キーは ``--api-key-file``(既定 ``materials_project.key``)、続いて環境変数 ``MP_API_KEY``、pymatgen 設定ファイル(``~/.config/.pmgrc.yaml``)の ``PMG_MAPI_KEY`` の順に、``getcif`` と同じ方法で解決されます。
 
   - ``--symprec`` *PREC*
 

--- a/docs/ja/source/cif2x/tutorial/index.rst
+++ b/docs/ja/source/cif2x/tutorial/index.rst
@@ -57,6 +57,7 @@ Quantum ESPRESSO の入力ファイルは、 ``&keyword`` で始まる Fortran90
 
 .. literalinclude:: ../../../../tutorial/cif2x/scf/scf.in
    :language: fortran
+   :force:
 
 カットオフ ``ecutwfc``, ``ecutrho`` の値が擬ポテンシャルファイルから取得され、 ``CELL_PARAMETERS``, ``ATOMIC_POSITIONS`` および ``ATOMIC_SPECIES`` の元素種が結晶構造データから決まり、 ``ATOMIC_SPECIES`` の擬ポテンシャルファイル名が ``optional.pp_file`` の対応付けから決まり、 ``K_POINTS`` が ``content.K_POINTS`` の設定(この例では ``grid: [8,8,8]``)から生成されていることが確認できます。
 
@@ -172,6 +173,7 @@ SCF 計算用の入力ファイルが ``scf/scf.in`` に書き出されます。
 
 .. literalinclude:: ../../../../tutorial/cif2x/respack/scf/scf.in
    :language: fortran
+   :force:
 
 NSCF 計算用の入力ファイル ``nscf/nscf.in`` では、``calculation = 'nscf'`` に加えて ``nosym``, ``noinv``, ``nbnd`` が設定され、``K_POINTS crystal`` に全 k 点が列挙されます (紙面の都合で k 点リストは省略します)。
 

--- a/docs/ja/source/getcif/index.rst
+++ b/docs/ja/source/getcif/index.rst
@@ -4,7 +4,6 @@ CIFデータ取得ツール (getcif)
 
 .. toctree::
    :maxdepth: 2
-   :numbered: 2
 
    about/index
    tutorial/index


### PR DESCRIPTION
## Summary

Follow-up recorded during the RESPACK tutorial review (#18): clean up the remaining Sphinx build warnings so `make html` is warning-free for both `docs/ja` and `docs/en`.

## Changes

- **Nested numbered toctree (5 warnings):** `getcif/index` is included from the cif2x toctree, which already sets `:numbered: 2`; the inner `:numbered: 2` in `getcif/index.rst` therefore tried to re-number already-numbered sections. Dropped the inner option (ja/en). Rendered numbering is unchanged — the outer assignment always won (verified 7. / 7.1. / 7.2. ... in the built HTML).
- **Fortran lexing retries (2 warnings):** the QE-input `literalinclude` blocks (QE and RESPACK tutorial `scf.in`) contain card options like `CELL_PARAMETERS {angstrom}` that are not valid Fortran tokens; Pygments warned and retried in relaxed mode, whose output is exactly what is rendered anyway. Added `:force:` to those two includes (ja/en) to silence the retry warning while keeping the highlighting.
- **Inline emphasis (1 warning):** `*ID*(例: ...)` in the ja command reference — docutils requires whitespace or closing punctuation after the end marker; added a space.

## Verification

- `rm -rf build && make html` in both `docs/ja` and `docs/en`: **0 warnings** (previously 8 in ja, 7 in en).
- getcif section numbers in the built HTML unchanged (7.x series from the outer toctree).
- `pytest tests/` → 270 passed (no source change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)