### PR TITLE
ci: fix the docs deploy workflow (e-pTeX disc4 crash + dead SSH deploy key)

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'issp-center-dev/cif2x'
     steps:
     - name: Inject slug/short variables

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -13,6 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-24.04
     if: github.repository == 'issp-center-dev/cif2x'
+    permissions:
+      contents: write
     steps:
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4.x
@@ -51,13 +53,6 @@ jobs:
           make latexpdf
         done
 
-    - name: Deploy Configuration
-      run: |
-          mkdir ~/.ssh
-          ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-          echo "${{ secrets.GH_ACTIONS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
-          chmod 400 ~/.ssh/id_rsa
-
     - name: Push
       env:
         GIT_USER: "HTP-tools Developers"
@@ -74,7 +69,6 @@ jobs:
           cd gh-pages
           git config --local user.name "${GIT_USER}"
           git config --local user.email "${GIT_EMAIL}"
-          git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
           git add manual
           if git commit -m "Deploy docs to ${TARGET_NAME} by GitHub Actions triggered by ${GITHUB_SHA}"
           then


### PR DESCRIPTION
## Summary

The deploy workflow (manual build + gh-pages publish, push-to-main only, so invisible in PR checks) has failed on every recorded run since 2026-06-28. Two independent problems:

1. **Japanese latexpdf crash**: `! This can't happen (disc4).` on a `\begin{quote}` after a Japanese paragraph — the known interaction between the LaTeX kernel's paragraph hooks and the old e-pTeX 3.x in ubuntu-22.04's TeX Live 2021, fixed in e-pTeX 4.0 (TeX Live 2022). The same sources build a 51-page PDF locally on TeX Live 2022. → move the runner to **ubuntu-24.04** (TeX Live 2023, e-pTeX 4.x).
2. **Dead deploy key** (surfaced only once the build passed): the push to gh-pages fails with `Permission denied (publickey)` — `GH_ACTIONS_DEPLOY_KEY` is no longer valid. → push with the workflow's own **`GITHUB_TOKEN`** (`permissions: contents: write`) over the HTTPS credentials `actions/checkout` already persists, and drop the SSH setup step. No repository secret is needed anymore (the old secret and its deploy key can be deleted).

Closes #20

## Verification

The workflow's built-in test trigger (a branch named `ghactions`) was used to verify both fixes end-to-end before this PR: run [28589214877](https://github.com/issp-center-dev/cif2x/actions/runs/28589214877) shows the LaTeX build passing on ubuntu-24.04 (failing only at the old SSH push), and the follow-up run on this exact head **succeeded end-to-end**, publishing `manual/ghactions/{ja,en}` (html + PDF) to gh-pages. That test directory will be removed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)